### PR TITLE
feat: post 영속성 관련 Port와 Adapter 추가

### DIFF
--- a/post/src/main/java/com/fx/post/adapter/out/persistence/repository/CommentRepository.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/repository/CommentRepository.java
@@ -1,4 +1,7 @@
 package com.fx.post.adapter.out.persistence.repository;
 
-public interface CommentRepository {
+import com.fx.post.adapter.out.persistence.entity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/CommentPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/CommentPersistenceAdapter.kt
@@ -1,0 +1,11 @@
+package com.fx.post.adapter.out.persistence
+
+import com.fx.global.annotation.hexagonal.PersistenceAdapter
+import com.fx.post.adapter.out.persistence.repository.CommentRepository
+import com.fx.post.application.out.CommentPersistencePort
+
+@PersistenceAdapter
+class CommentPersistenceAdapter(
+    private val commentRepository: CommentRepository
+) : CommentPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/LikePersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/LikePersistenceAdapter.kt
@@ -1,0 +1,11 @@
+package com.fx.post.adapter.out.persistence
+
+import com.fx.global.annotation.hexagonal.PersistenceAdapter
+import com.fx.post.adapter.out.persistence.repository.LikeRepository
+import com.fx.post.application.out.LikePersistencePort
+
+@PersistenceAdapter
+class LikePersistenceAdapter(
+    private val likeRepository: LikeRepository
+) : LikePersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
@@ -1,0 +1,11 @@
+package com.fx.post.adapter.out.persistence
+
+import com.fx.global.annotation.hexagonal.PersistenceAdapter
+import com.fx.post.adapter.out.persistence.repository.PostMediaRepository
+import com.fx.post.application.out.PostMediaPersistencePort
+
+@PersistenceAdapter
+class PostMediaPersistenceAdapter(
+    private val postMediaRepository: PostMediaRepository
+) : PostMediaPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
@@ -1,0 +1,11 @@
+package com.fx.post.adapter.out.persistence
+
+import com.fx.global.annotation.hexagonal.PersistenceAdapter
+import com.fx.post.adapter.out.persistence.repository.PostRepository
+import com.fx.post.application.out.PostPersistencePort
+
+@PersistenceAdapter
+class PostPersistenceAdapter(
+    private val postRepository: PostRepository
+) : PostPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/CommentPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/CommentPersistencePort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out
+
+interface CommentPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/LikePersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/LikePersistencePort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out
+
+interface LikePersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/PostMediaPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/PostMediaPersistencePort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out
+
+interface PostMediaPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out
+
+interface PostPersistencePort {
+}


### PR DESCRIPTION
feat: post 영속성 관련 Port와 Adapter 추가

- CommentRepository에서 JpaRepository 상속
- PostPersisteneceAdapter 추가
- PostMediaPersistenceAdapter 추가
- CommentPersistenceAdapter 추가
- LikePersistenceAdapter 추가
- PostPersistenecePort 추가
- PostMediaPersistencePort 추가
- CommentPersistencePort 추가
- LikePersistencePort 추가