### PR TITLE
feat: 게시글 작성에 인가 객체 추가

### DIFF
--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
@@ -1,7 +1,9 @@
 package com.fx.post.adapter.`in`.web
 
+import com.fx.global.annotation.AuthenticatedUser
 import com.fx.global.annotation.hexagonal.WebAdapter
 import com.fx.global.api.Api
+import com.fx.global.resolver.AuthUser
 import com.fx.post.adapter.`in`.web.dto.*
 import com.fx.post.application.`in`.PostCommandUseCase
 import jakarta.validation.Valid
@@ -19,8 +21,11 @@ class PostApiAdapter(
     private val postCommandUseCase: PostCommandUseCase
 ) {
     @PostMapping("/posts")
-    fun createPost(@RequestBody @Valid postCreateRequest: PostCreateRequest): ResponseEntity<Api<PostCreateResponse>> {
-        val post = postCommandUseCase.createPost(postCreateRequest.toCommand())
+    fun createPost(
+        @RequestBody @Valid postCreateRequest: PostCreateRequest,
+        @AuthenticatedUser authUser: AuthUser
+    ): ResponseEntity<Api<PostCreateResponse>> {
+        val post = postCommandUseCase.createPost(postCreateRequest.toCommand(authUser))
         return Api.OK(PostCreateResponse(post.id))
     }
 

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostCreateRequest.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostCreateRequest.kt
@@ -1,18 +1,17 @@
 package com.fx.post.adapter.`in`.web.dto
 
+import com.fx.global.resolver.AuthUser
 import com.fx.post.application.`in`.dto.PostCreateCommand
 import jakarta.validation.constraints.Size
 
 data class PostCreateRequest(
-    // 임시로 userId를 직접 받음
-    val userId: Long,
     @field:Size(max = 2000, message = "게시글은 2000자 이내여야 합니다.")
     val content: String,
     //val mediaIds: List<Long>
 ) {
-    fun toCommand(): PostCreateCommand {
+    fun toCommand(authUser: AuthUser): PostCreateCommand {
         return PostCreateCommand(
-            userId = this.userId,
+            userId = authUser.userId,
             content = this.content,
             //mediaIds = this.mediaIds
         )

--- a/post/src/main/kotlin/com/fx/post/application/in/dto/PostCreateCommand.kt
+++ b/post/src/main/kotlin/com/fx/post/application/in/dto/PostCreateCommand.kt
@@ -1,7 +1,7 @@
 package com.fx.post.application.`in`.dto
 
+
 data class PostCreateCommand(
-    //임시로 유저아이디를 받음
     val userId: Long,
     val content: String? = null,
     //val mediaIds: List<Long>


### PR DESCRIPTION
feat: 게시글 작성에 인가 객체 추가

- PostApiAdapter에 인수로 AuthUser 추가
- PostCreateRequest에 userId 필드 삭제
- PostCreateRequest의 toCommand의 인수로 AuthUser를 받고 userId값으로 커맨드 객체 생성