### PR TITLE
feat: 댓글 작성에 인가 객체 추가

### DIFF
--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
@@ -30,8 +30,11 @@ class PostApiAdapter(
     }
 
     @PostMapping("/posts/{postId}/comments")
-    fun createComment(@PathVariable postId: Long, @RequestBody @Valid commentCreateRequest: CommentCreateRequest): ResponseEntity<Api<CommentCreateResponse>> {
-        val comment = postCommandUseCase.createComment(postId,commentCreateRequest.toCommand())
+    fun createComment(
+        @PathVariable postId: Long,
+        @RequestBody @Valid commentCreateRequest: CommentCreateRequest,
+        @AuthenticatedUser authUser: AuthUser): ResponseEntity<Api<CommentCreateResponse>> {
+        val comment = postCommandUseCase.createComment(postId,commentCreateRequest.toCommand(authUser))
         return Api.OK(CommentCreateResponse(comment.id))
     }
 

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/CommentCreateRequest.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/CommentCreateRequest.kt
@@ -1,20 +1,19 @@
 package com.fx.post.adapter.`in`.web.dto
 
+import com.fx.global.resolver.AuthUser
 import com.fx.post.application.`in`.dto.CommentCreateCommand
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class CommentCreateRequest(
-    // 임시로 userId를 받음
-    val userId: Long,
     @field:NotBlank(message = "댓글 내용은 필수입니다.")
     @field:Size(max = 500, message = "댓글은 500자 이내여야 합니다.")
     val content: String,
     val parentId: Long? = null
 ) {
-    fun toCommand(): CommentCreateCommand {
+    fun toCommand(authUser: AuthUser): CommentCreateCommand {
         return CommentCreateCommand(
-            userId = this.userId,
+            userId = authUser.userId,
             content = this.content,
             parentId = this.parentId
         )


### PR DESCRIPTION
feat: 댓글 작성에 인가 객체 추가

- PostApiAdapter에 인수로 AuthUser 추가
- CommentCreateRequest에 userId 필드 삭제
- CommentCreateRequest의 toCommand의 인수로 AuthUser를 받고 userId값으로 커맨드 객체 생성