### PR TITLE
feat: 게시글 수정 개발

### DIFF
--- a/post/src/main/java/com/fx/post/adapter/out/persistence/entity/PostEntity.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/entity/PostEntity.java
@@ -24,6 +24,7 @@ public class PostEntity extends BaseEntity {
 
     public static PostEntity from(Post post) {
         return PostEntity.builder()
+                .id(post.getId())
                 .userId(post.getUserId())
                 .content(post.getContent())
                 .isDeleted(post.isDeleted())

--- a/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
@@ -4,8 +4,11 @@ import com.fx.post.adapter.out.persistence.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
     Boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    Optional<PostEntity> findByIdAndIsDeletedNot(Long id, Boolean isDeleted);
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
@@ -10,6 +10,7 @@ import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Objects
@@ -29,6 +30,17 @@ class PostApiAdapter(
         return Api.OK(PostCreateResponse(post.id))
     }
 
+    @PutMapping("/posts/{postId}")
+    fun updatePost(
+        @PathVariable postId: Long,
+        @RequestBody @Valid postUpdateRequest: PostUpdateRequest,
+        @AuthenticatedUser authUser: AuthUser
+    ): ResponseEntity<Api<PostUpdateResponse>> {
+        val post = postCommandUseCase.updatePost(postId, postUpdateRequest.toCommand(authUser))
+        return Api.OK(PostUpdateResponse(post.id))
+    }
+
+
     @PostMapping("/posts/{postId}/comments")
     fun createComment(
         @PathVariable postId: Long,
@@ -43,7 +55,6 @@ class PostApiAdapter(
         @PathVariable postId: Long,
         @AuthenticatedUser authUser: AuthUser
         ): ResponseEntity<Api<Unit?>> {
-        // 인가 처리 완료 시 likeDto 대신 인가 객체로 변경 예정
         postCommandUseCase.addLike(postId, authUser.userId)
         return Api.OK(null)
     }

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostUpdateRequest.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostUpdateRequest.kt
@@ -1,0 +1,19 @@
+package com.fx.post.adapter.`in`.web.dto
+
+import com.fx.global.resolver.AuthUser
+import com.fx.post.application.`in`.dto.PostUpdateCommand
+import jakarta.validation.constraints.Size
+
+data class PostUpdateRequest(
+    @field:Size(max = 2000, message = "게시글은 2000자 이내여야 합니다.")
+    val content: String,
+    //val mediaIds: List<Long>
+) {
+    fun toCommand(authUser: AuthUser): PostUpdateCommand {
+        return PostUpdateCommand(
+            userId = authUser.userId,
+            role = authUser.role,
+            content = this.content
+        )
+    }
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostUpdateResponse.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostUpdateResponse.kt
@@ -1,0 +1,5 @@
+package com.fx.post.adapter.`in`.web.dto
+
+data class PostUpdateResponse(
+    val postId: Long?
+)

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
@@ -20,4 +20,7 @@ class PostPersistenceAdapter(
 
     override fun existsById(postId: Long): Boolean =
         postRepository.existsById(postId)
+
+    override fun findByIdAndIsDeletedNot(postId: Long): Post? =
+        postRepository.findByIdAndIsDeletedNot(postId, true).orElse(null)?.toDomain()
 }

--- a/post/src/main/kotlin/com/fx/post/application/in/PostCommandUseCase.kt
+++ b/post/src/main/kotlin/com/fx/post/application/in/PostCommandUseCase.kt
@@ -2,12 +2,15 @@ package com.fx.post.application.`in`
 
 import com.fx.post.application.`in`.dto.CommentCreateCommand
 import com.fx.post.application.`in`.dto.PostCreateCommand
+import com.fx.post.application.`in`.dto.PostUpdateCommand
 import com.fx.post.domain.Comment
 import com.fx.post.domain.Post
 
 interface PostCommandUseCase {
 
     fun createPost(postCreateCommand: PostCreateCommand): Post
+
+    fun updatePost(postId:Long, postUpdateCommand: PostUpdateCommand): Post
 
     fun createComment(postId:Long, commentCreateCommand: CommentCreateCommand): Comment
 

--- a/post/src/main/kotlin/com/fx/post/application/in/dto/PostUpdateCommand.kt
+++ b/post/src/main/kotlin/com/fx/post/application/in/dto/PostUpdateCommand.kt
@@ -1,0 +1,10 @@
+package com.fx.post.application.`in`.dto
+
+import com.fx.global.dto.UserRole
+
+class PostUpdateCommand(
+    val userId: Long,
+    val role: UserRole,
+    val content: String,
+    //val mediaIds: List<Long>
+)

--- a/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
@@ -10,4 +10,6 @@ interface PostPersistencePort {
     fun existsByUserIdAndCreatedAtBetween(userId: Long, start: LocalDateTime, end: LocalDateTime): Boolean
 
     fun existsById(postId: Long): Boolean
+
+    fun findByIdAndIsDeletedNot(postId: Long): Post?
 }

--- a/post/src/main/kotlin/com/fx/post/domain/Post.kt
+++ b/post/src/main/kotlin/com/fx/post/domain/Post.kt
@@ -1,6 +1,7 @@
 package com.fx.post.domain
 
 import com.fx.post.application.`in`.dto.PostCreateCommand
+import com.fx.post.application.`in`.dto.PostUpdateCommand
 import java.time.LocalDateTime
 
 data class Post(
@@ -18,6 +19,16 @@ data class Post(
             return Post(
                 userId = postCreateCommand.userId,
                 content = postCreateCommand.content
+            )
+        }
+
+        @JvmStatic
+        fun updatePost(postId:Long, userId: Long, today: LocalDateTime, postUpdateCommand: PostUpdateCommand): Post {
+            return Post(
+                id = postId,
+                userId = userId,
+                content = postUpdateCommand.content,
+                updatedAt = today
             )
         }
 

--- a/post/src/main/kotlin/com/fx/post/exception/errorcode/PostErrorCode.kt
+++ b/post/src/main/kotlin/com/fx/post/exception/errorcode/PostErrorCode.kt
@@ -8,5 +8,7 @@ enum class PostErrorCode(
     override val message: String
 ) : ErrorCodeIfs {
     DUPLICATE_DAILY_POST(HttpStatus.CONFLICT, message = "하루에 하나만 작성할 수 있습니다."),
-    POST_NOT_EXIST(HttpStatus.CONFLICT, message = "게시글이 존재하지 않습니다.")
+    POST_NOT_EXIST(HttpStatus.CONFLICT, message = "게시글이 존재하지 않습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, message = "게시글을 수정할 권한이 없습니다."),
+    POST_EDIT_DATE_MISMATCH(HttpStatus.CONFLICT, message = "작성일 기준 당일에만 수정할 수 있습니다.")
 }


### PR DESCRIPTION
feat: 게시글 수정 개발

- POST_FORBIDDEN, POST_EDIT_DATE_MISMATCH 예외 개발
- PostEntity의 from빌더에 id값도 추가(미기입시 새로 작성)
- Post 객체의 updatePost 메소드 인수에는 DB에서 받아온 userId값을 사용(ADMIN이 수정 시 ADMIN의 userId 값으로 변경되지 않게)