### PR TITLE
feat: 게시글 조회(팔로워, 자신, 특정 유저) 개발

### DIFF
--- a/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
@@ -1,9 +1,13 @@
 package com.fx.post.adapter.out.persistence.repository;
 
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto;
 import com.fx.post.adapter.out.persistence.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
@@ -11,4 +15,19 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     Boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
     Optional<PostEntity> findByIdAndIsDeletedNot(Long id, Boolean isDeleted);
+
+    @Query("""
+    SELECT new com.fx.post.adapter.out.persistence.dto.PostSummaryDto(
+            p.id, p.userId, p.content, p.createdAt,
+            count(distinct l.id), count(distinct c.id)
+        )
+        from PostEntity p
+        left join LikeEntity l on l.postId = p.id
+        left join CommentEntity c on c.postId = p.id
+        where p.userId in :userIds and p.createdAt < :before and p.isDeleted != :isDeleted
+        group by p.id, p.userId, p.content, p.createdAt
+        order by p.createdAt desc
+        limit 10
+    """)
+    List<PostSummaryDto> findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(@Param("userIds") List<Long> userIds, @Param("before") LocalDateTime before, @Param("isDeleted") Boolean isDeleted);
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
@@ -7,10 +7,10 @@ import com.fx.global.resolver.AuthUser
 import com.fx.post.adapter.`in`.web.dto.*
 import com.fx.post.application.`in`.PostCommandUseCase
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.util.Objects
-import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType
+import java.time.LocalDateTime
 
 @WebAdapter
 @RequestMapping("/api/v1/post")
@@ -24,6 +24,30 @@ class PostApiAdapter(
     ): ResponseEntity<Api<PostCreateResponse>> {
         val post = postCommandUseCase.createPost(postCreateRequest.toCommand(authUser))
         return Api.OK(PostCreateResponse(post.id))
+    }
+
+    @GetMapping("/posts")
+    fun getFollowersPosts(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) before: LocalDateTime,
+                          @AuthenticatedUser authUser: AuthUser
+    ): ResponseEntity<Api<List<PostResponse>>> {
+        val posts = postCommandUseCase.getFollowersPosts(authUser.userId, before)
+        return Api.OK(posts.map { PostResponse.from(it) })
+    }
+
+    @GetMapping("/posts/me")
+    fun getMyPosts(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) before: LocalDateTime,
+                 @AuthenticatedUser authUser: AuthUser
+    ): ResponseEntity<Api<List<PostResponse>>> {
+        val posts = postCommandUseCase.getMyPosts(authUser.userId, before)
+        return Api.OK(posts.map { PostResponse.from(it) })
+    }
+
+    @GetMapping("/posts/{userId}")
+    fun getUserPosts(@PathVariable userId: Long,
+                     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) before: LocalDateTime
+    ): ResponseEntity<Api<List<PostResponse>>> {
+        val posts = postCommandUseCase.getUserPosts(userId, before)
+        return Api.OK(posts.map { PostResponse.from(it) })
     }
 
     @PutMapping("/posts/{postId}")

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostResponse.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostResponse.kt
@@ -1,0 +1,30 @@
+package com.fx.post.adapter.`in`.web.dto
+
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
+import java.time.LocalDateTime
+
+data class PostResponse(
+    val postId: Long,
+    val userId: Long,
+    //val nickname: String,
+    //val profileImageUrl: String? = null,
+    val content: String?,
+    //val mediaUrls: List<String>,
+    val createdAt: LocalDateTime,
+    val likeCount: Long,
+    val commentCount: Long
+) {
+    companion object {
+        fun from(postSummaryDto: PostSummaryDto): PostResponse{
+            return PostResponse(
+                postId = postSummaryDto.id,
+                userId = postSummaryDto.userId,
+                content = postSummaryDto.content,
+                createdAt = postSummaryDto.createdAt,
+                likeCount = postSummaryDto.likeCount,
+                commentCount = postSummaryDto.commentCount
+            )
+        }
+    }
+
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package com.fx.post.adapter.out.persistence
 
 import com.fx.global.annotation.hexagonal.PersistenceAdapter
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.adapter.out.persistence.entity.PostEntity
 import com.fx.post.adapter.out.persistence.repository.PostRepository
 import com.fx.post.application.out.PostPersistencePort
@@ -14,6 +15,9 @@ class PostPersistenceAdapter(
 
     override fun save(post: Post): Post =
         postRepository.save(PostEntity.from(post)).toDomain()
+
+    override fun findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(userIds: List<Long>, createdAt: LocalDateTime): List<PostSummaryDto> =
+        postRepository.findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(userIds, createdAt, true)
 
     override fun existsByUserIdAndCreatedAtBetween(userId:Long, start: LocalDateTime, end: LocalDateTime): Boolean =
         postRepository.existsByUserIdAndCreatedAtBetween(userId, start, end)

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/dto/PostSummaryDto.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/dto/PostSummaryDto.kt
@@ -1,0 +1,12 @@
+package com.fx.post.adapter.out.persistence.dto
+
+import java.time.LocalDateTime
+
+data class PostSummaryDto(
+    var id: Long,
+    val userId: Long,
+    val content: String,
+    val createdAt: LocalDateTime,
+    val likeCount: Long,
+    val commentCount: Long,
+)

--- a/post/src/main/kotlin/com/fx/post/application/in/PostCommandUseCase.kt
+++ b/post/src/main/kotlin/com/fx/post/application/in/PostCommandUseCase.kt
@@ -1,14 +1,22 @@
 package com.fx.post.application.`in`
 
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.application.`in`.dto.CommentCreateCommand
 import com.fx.post.application.`in`.dto.PostCreateCommand
 import com.fx.post.application.`in`.dto.PostUpdateCommand
 import com.fx.post.domain.Comment
 import com.fx.post.domain.Post
+import java.time.LocalDateTime
 
 interface PostCommandUseCase {
 
     fun createPost(postCreateCommand: PostCreateCommand): Post
+
+    fun getFollowersPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto>
+
+    fun getMyPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto>
+
+    fun getUserPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto>
 
     fun updatePost(postId:Long, postUpdateCommand: PostUpdateCommand): Post
 

--- a/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/PostPersistencePort.kt
@@ -1,5 +1,6 @@
 package com.fx.post.application.out
 
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.domain.Post
 import java.time.LocalDateTime
 
@@ -12,4 +13,6 @@ interface PostPersistencePort {
     fun existsById(postId: Long): Boolean
 
     fun findByIdAndIsDeletedNot(postId: Long): Post?
+
+    fun findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(userIds: List<Long>, createdAt: LocalDateTime): List<PostSummaryDto>
 }

--- a/post/src/main/kotlin/com/fx/post/application/service/PostCommandService.kt
+++ b/post/src/main/kotlin/com/fx/post/application/service/PostCommandService.kt
@@ -1,6 +1,7 @@
 package com.fx.post.application.service
 
 import com.fx.global.dto.UserRole
+import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.application.`in`.PostCommandUseCase
 import com.fx.post.application.`in`.dto.CommentCreateCommand
 import com.fx.post.application.`in`.dto.PostCreateCommand
@@ -44,6 +45,26 @@ class PostCommandService(
 
         val savedPost = postPersistencePort.save(Post.createPost(postCreateCommand))
         return savedPost
+    }
+
+    override fun getFollowersPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto> {
+        // 유저 모듈에서 FeignClient로 팔로우 리스트 가져오기(미구현)
+        val followers = listOf(1L, 2L) // 임시 구현
+        val posts = postPersistencePort.findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(followers, before)
+        // 유저 모듈에서 FeignClient로 follower들의 닉네임을 가져온 뒤 매핑하기(미구현)
+        return posts
+    }
+
+    override fun getMyPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto> {
+        val posts = postPersistencePort.findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(listOf(userId), before)
+        // 유저 모듈에서 FeignClient로 userId들의 닉네임들 가져온 뒤 매핑하기(미구현)
+        return posts
+    }
+
+    override fun getUserPosts(userId: Long, before: LocalDateTime): List<PostSummaryDto> {
+        val posts = postPersistencePort.findByUserIdInAndCreatedAtBeforeAndIsDeletedNot(listOf(userId), before)
+        // 유저 모듈에서 FeignClient로 userId들의 닉네임들 가져온 뒤 매핑하기(미구현)
+        return posts
     }
 
     @Transactional


### PR DESCRIPTION
feat: 게시글 조회(팔로워, 자신, 특정 유저) 개발

- 팔로워들 게시글, 자신의 게시글, 특정 유저의 게시글 조회 개발
- 성능을 위해 2중 조인 JPQL 사용
- 좋아요와 댓글 게시글의 개수를 담기 위해 PostSummaryDto 개발
- nickname, profileImageUrl, mediaUrls 미구현