### PR TITLE
Refactor: 분리된 외부 포트 패키지 구조 적용 및 FeignClient 어댑터 추가

### DIFF
--- a/post/build.gradle.kts
+++ b/post/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/post/src/main/kotlin/com/fx/post/PostApplication.kt
+++ b/post/src/main/kotlin/com/fx/post/PostApplication.kt
@@ -3,12 +3,14 @@ package com.fx.post
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @ComponentScan(basePackages = ["com.fx.post", "com.fx.global"])
 @EnableJpaAuditing
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication
 class PostApplication
 

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/CommentPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/CommentPersistenceAdapter.kt
@@ -3,7 +3,7 @@ package com.fx.post.adapter.out.persistence
 import com.fx.global.annotation.hexagonal.PersistenceAdapter
 import com.fx.post.adapter.out.persistence.entity.CommentEntity
 import com.fx.post.adapter.out.persistence.repository.CommentRepository
-import com.fx.post.application.out.CommentPersistencePort
+import com.fx.post.application.out.persistence.CommentPersistencePort
 import com.fx.post.domain.Comment
 
 @PersistenceAdapter

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/LikePersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/LikePersistenceAdapter.kt
@@ -3,7 +3,7 @@ package com.fx.post.adapter.out.persistence
 import com.fx.global.annotation.hexagonal.PersistenceAdapter
 import com.fx.post.adapter.out.persistence.entity.LikeEntity
 import com.fx.post.adapter.out.persistence.repository.LikeRepository
-import com.fx.post.application.out.LikePersistencePort
+import com.fx.post.application.out.persistence.LikePersistencePort
 import com.fx.post.domain.Like
 
 @PersistenceAdapter

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
@@ -2,7 +2,7 @@ package com.fx.post.adapter.out.persistence
 
 import com.fx.global.annotation.hexagonal.PersistenceAdapter
 import com.fx.post.adapter.out.persistence.repository.PostMediaRepository
-import com.fx.post.application.out.PostMediaPersistencePort
+import com.fx.post.application.out.persistence.PostMediaPersistencePort
 
 @PersistenceAdapter
 class PostMediaPersistenceAdapter(

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostPersistenceAdapter.kt
@@ -4,7 +4,7 @@ import com.fx.global.annotation.hexagonal.PersistenceAdapter
 import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.adapter.out.persistence.entity.PostEntity
 import com.fx.post.adapter.out.persistence.repository.PostRepository
-import com.fx.post.application.out.PostPersistencePort
+import com.fx.post.application.out.persistence.PostPersistencePort
 import com.fx.post.domain.Post
 import java.time.LocalDateTime
 

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/client/UserFeignClient.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/client/UserFeignClient.kt
@@ -1,0 +1,7 @@
+package com.fx.post.adapter.out.web.client
+
+import org.springframework.cloud.openfeign.FeignClient
+
+@FeignClient(name = "user-service", path = "/internal")
+interface UserFeignClient {
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/UserWebAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/UserWebAdapter.kt
@@ -1,0 +1,12 @@
+package com.fx.post.adapter.out.web.impl
+
+import com.fx.post.adapter.out.web.client.UserFeignClient
+import com.fx.post.application.out.web.UserWebPort
+import org.springframework.stereotype.Component
+
+@Component // WebOutputAdapter 등 추가 시 변경 예정
+class UserWebAdapter(
+    private val userFeignClient: UserFeignClient
+) : UserWebPort{
+
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/PostMediaPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/PostMediaPersistencePort.kt
@@ -1,4 +1,0 @@
-package com.fx.post.application.out
-
-interface PostMediaPersistencePort {
-}

--- a/post/src/main/kotlin/com/fx/post/application/out/persistence/CommentPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/persistence/CommentPersistencePort.kt
@@ -1,4 +1,4 @@
-package com.fx.post.application.out
+package com.fx.post.application.out.persistence
 
 import com.fx.post.domain.Comment
 

--- a/post/src/main/kotlin/com/fx/post/application/out/persistence/LikePersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/persistence/LikePersistencePort.kt
@@ -1,4 +1,4 @@
-package com.fx.post.application.out
+package com.fx.post.application.out.persistence
 
 import com.fx.post.domain.Like
 

--- a/post/src/main/kotlin/com/fx/post/application/out/persistence/PostMediaPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/persistence/PostMediaPersistencePort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out.persistence
+
+interface PostMediaPersistencePort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/persistence/PostPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/persistence/PostPersistencePort.kt
@@ -1,4 +1,4 @@
-package com.fx.post.application.out
+package com.fx.post.application.out.persistence
 
 import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.domain.Post

--- a/post/src/main/kotlin/com/fx/post/application/out/web/UserWebPort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/web/UserWebPort.kt
@@ -1,0 +1,4 @@
+package com.fx.post.application.out.web
+
+interface UserWebPort {
+}

--- a/post/src/main/kotlin/com/fx/post/application/service/PostCommandService.kt
+++ b/post/src/main/kotlin/com/fx/post/application/service/PostCommandService.kt
@@ -6,10 +6,11 @@ import com.fx.post.application.`in`.PostCommandUseCase
 import com.fx.post.application.`in`.dto.CommentCreateCommand
 import com.fx.post.application.`in`.dto.PostCreateCommand
 import com.fx.post.application.`in`.dto.PostUpdateCommand
-import com.fx.post.application.out.CommentPersistencePort
-import com.fx.post.application.out.LikePersistencePort
-import com.fx.post.application.out.PostMediaPersistencePort
-import com.fx.post.application.out.PostPersistencePort
+import com.fx.post.application.out.persistence.CommentPersistencePort
+import com.fx.post.application.out.persistence.LikePersistencePort
+import com.fx.post.application.out.persistence.PostMediaPersistencePort
+import com.fx.post.application.out.persistence.PostPersistencePort
+import com.fx.post.application.out.web.UserWebPort
 import com.fx.post.domain.Comment
 import com.fx.post.domain.Like
 import com.fx.post.domain.Post
@@ -29,7 +30,8 @@ class PostCommandService(
     private val postPersistencePort: PostPersistencePort,
     private val postMediaPersistencePort: PostMediaPersistencePort,
     private val commentPersistencePort: CommentPersistencePort,
-    private val likePersistencePort: LikePersistencePort
+    private val likePersistencePort: LikePersistencePort,
+    private val userWebPort: UserWebPort
 ) : PostCommandUseCase {
 
     @Transactional


### PR DESCRIPTION
Refactor: 분리된 외부 포트 패키지 구조 적용 및 FeignClient 어댑터 추가

- OpenFeign 의존성 추가
- application/out에 persistence, web 포트 인터페이스 분리
- adapter/out에 FeignClient 인터페이스(client) 및 포트 구현체(adapter) 구조 적용
- UserWebPort, UserFeignClient, UserWebAdapter 구현체 추가
- PostPersistencePort와 LikePersistencePort는 application/out/persistence에 위치
- 헥사고날 아키텍처 원칙에 맞게 관심사 분리 및 모듈화