### PR TITLE
feat: PostEntity, CommentEntity, LikeEntity 인덱스 추가

### DIFF
--- a/post/src/main/java/com/fx/post/adapter/out/persistence/entity/CommentEntity.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/entity/CommentEntity.java
@@ -3,6 +3,7 @@ package com.fx.post.adapter.out.persistence.entity;
 import com.fx.post.domain.Comment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
-@Table(name = "comment")
+@Table(name = "comment",
+        indexes = {
+        @Index(name = "idx_comment_postid_createdat", columnList = "post_id, created_at"),
+        @Index(name = "idx_comment_userid_createdat", columnList = "user_id, created_at"),
+})
 @SuperBuilder
 @NoArgsConstructor
 public class CommentEntity extends BaseEntity {

--- a/post/src/main/java/com/fx/post/adapter/out/persistence/entity/LikeEntity.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/entity/LikeEntity.java
@@ -2,6 +2,7 @@ package com.fx.post.adapter.out.persistence.entity;
 
 import com.fx.post.domain.Like;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,11 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
-@Table(name = "likes")
+@Table(name = "likes",
+        indexes = {
+                @Index(name = "idx_likes_postid_userid", columnList = "post_id, user_id"),
+                @Index(name = "idx_likes_postid", columnList = "post_id")
+        })
 @SuperBuilder
 @NoArgsConstructor
 public class LikeEntity extends BaseEntity {

--- a/post/src/main/java/com/fx/post/adapter/out/persistence/entity/PostEntity.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/entity/PostEntity.java
@@ -3,6 +3,7 @@ package com.fx.post.adapter.out.persistence.entity;
 import com.fx.post.domain.Post;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,10 @@ import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
-@Table(name = "post")
+@Table(name = "post",
+        indexes = {
+            @Index(name = "idx_post_userid_isdeleted_createdat", columnList = "user_id, is_deleted, created_at")
+        })
 @SuperBuilder
 @NoArgsConstructor
 public class PostEntity extends BaseEntity {

--- a/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostRepository.java
@@ -39,7 +39,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
         from PostEntity p
         left join LikeEntity l on l.postId = p.id
         left join CommentEntity c on c.postId = p.id
-        where l.userId = :userId and p.createdAt < :before and p.isDeleted = :isDeleted
+        where p.userId = :userId and p.createdAt < :before and p.isDeleted = :isDeleted
         group by p.id, p.userId, p.content, p.createdAt
         order by p.createdAt desc
         limit 10


### PR DESCRIPTION
feat: PostEntity, CommentEntity, LikeEntity 인덱스 추가

- PostEntity @ idx_post_userid_isdeleted_createdat(user_id, is_deleted, created_at) 인덱스 추가
- CommentEntity @ idx_comment_postid_createdat(post_id, created_at) 추가 @ idx_comment_userid_createdat(user_id, created_at) 추가
- LikeEntity @ idx_likes_postid_userid(post_id, user_id) 추가
@ idx_likes_postid(post_id) 추가

게시글 조회 쿼리 실행 계획 분석(UserId 종류 100개, 레코드 100,000개)

인덱스를 탔을 떄
-> Limit: 10 row(s)  (actual time=13..13 rows=10 loops=1)
     -> Sort: p.created_at DESC, limit input to 10 row(s) per chunk  (actual time=13..13 rows=10 loops=1)
         -> Stream results  (cost=3399 rows=2425) (actual time=4.67..12.5 rows=1922 loops=1)...
cost: 3,399 (낮음)
실제 처리 시간: 약 13ms
읽은 row 수: 약 1,922개

인덱스를 탔을 때
-> Limit: 10 row(s)  (actual time=49.6..49.6 rows=10 loops=1)
     -> Sort: p.created_at DESC, limit input to 10 row(s) per chunk  (actual time=49.6..49.6 rows=10 loops=1)
         -> Stream results  (cost=82562 rows=83946) (actual time=41.6..49.2 rows=192...
cost: 82,562 (매우 높음)
실제 처리 시간: 약 50ms
읽은 row 수: 약 83,946개