### PR TITLE
refactor: Jwt 저장 로직 CachePort로 분리

### DIFF
--- a/user/src/main/kotlin/com/fx/user/adapter/out/cache/RedisJwtCacheAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/cache/RedisJwtCacheAdapter.kt
@@ -1,0 +1,23 @@
+package com.fx.user.adapter.out.cache
+
+import com.fx.global.annotation.hexagonal.CacheAdapter
+import com.fx.user.application.out.JwtCachePort
+import jakarta.servlet.http.HttpSession
+import java.util.*
+
+@CacheAdapter
+class RedisJwtCacheAdapter(
+    private val httpSession: HttpSession
+): JwtCachePort {
+    private val REFRESHTOKEN: String = "refreshToken"
+
+    override fun saveToken(refreshToken: String, expiration: Date) {
+        httpSession.setAttribute(REFRESHTOKEN, refreshToken)
+        httpSession.maxInactiveInterval = ((expiration.time - Date().time) / 1000).toInt()
+    }
+
+    override fun getToken(): String? {
+        return httpSession.getAttribute(REFRESHTOKEN)?.toString()
+    }
+
+}

--- a/user/src/main/kotlin/com/fx/user/application/out/JwtCachePort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/out/JwtCachePort.kt
@@ -1,0 +1,9 @@
+package com.fx.user.application.out
+
+import java.util.*
+
+interface JwtCachePort {
+    fun saveToken(refreshToken: String, expiration: Date)
+
+    fun getToken(): String?
+}


### PR DESCRIPTION
refactor: Jwt 저장 로직 JwtCachePort로 분리

- JwtCachePort 개발
- RedisJwtCacheAdapter 개발 및 JwtProvider에서 로직 분리(세션 저장, 세션 조회)