### PR TITLE
refactor: 파일 업로드 로직 리팩토링

### DIFF
--- a/media/src/main/kotlin/com/fx/media/adapter/in/web/MediaApiAdapter.kt
+++ b/media/src/main/kotlin/com/fx/media/adapter/in/web/MediaApiAdapter.kt
@@ -6,6 +6,7 @@ import com.fx.global.api.Api
 import com.fx.global.resolver.AuthUser
 import com.fx.media.adapter.`in`.web.dto.Context
 import com.fx.media.adapter.`in`.web.dto.MediaUploadResponse
+import com.fx.media.adapter.out.storage.dto.FileStoreCommand
 import com.fx.media.application.`in`.MediaCommandUseCase
 import com.fx.media.application.`in`.MediaQueryUseCase
 import com.fx.media.application.`in`.dto.MediaUploadCommand
@@ -28,21 +29,9 @@ class MediaApiAdapter (
         @AuthenticatedUser authUser: AuthUser
     ) : ResponseEntity<Api<List<MediaUploadResponse>>> {
 
-        val mediaResponses = files.map { mediaCommandUseCase.uploadFile(MediaUploadCommand(it, context, authUser.userId)) }
-
+        val mediaResponses = mediaCommandUseCase.uploadFile(MediaUploadCommand(files, context, authUser.userId))
         return Api.OK(mediaResponses.map { MediaUploadResponse.from(it) })
     }
 
-    @PostMapping("/without")
-    fun uploadFileWithoutCoroutine(
-        @RequestParam("files") files: List<MultipartFile>,
-        @RequestParam context: Context,
-        @AuthenticatedUser authUser: AuthUser
-    ) : ResponseEntity<Api<List<MediaUploadResponse>>> {
-
-        val mediaResponses = files.map { mediaCommandUseCase.uploadFileWithoutCoroutine(MediaUploadCommand(it, context, authUser.userId)) }
-
-        return Api.OK(mediaResponses.map { MediaUploadResponse.from(it) })
-    }
 
 }

--- a/media/src/main/kotlin/com/fx/media/adapter/out/storage/dto/FileStoreCommand.kt
+++ b/media/src/main/kotlin/com/fx/media/adapter/out/storage/dto/FileStoreCommand.kt
@@ -1,0 +1,20 @@
+package com.fx.media.adapter.out.storage.dto
+
+import com.fx.media.adapter.`in`.web.dto.Context
+import org.springframework.web.multipart.MultipartFile
+
+data class FileStoreCommand(
+    val file: MultipartFile,
+    val context: Context,
+    val userId: Long?= null
+) {
+    companion object {
+        fun storeFile(file: MultipartFile, context: Context, userId: Long?= null): FileStoreCommand {
+            return FileStoreCommand(
+                file = file,
+                context = context,
+                userId = userId
+            )
+        }
+    }
+}

--- a/media/src/main/kotlin/com/fx/media/application/in/MediaCommandUseCase.kt
+++ b/media/src/main/kotlin/com/fx/media/application/in/MediaCommandUseCase.kt
@@ -5,7 +5,6 @@ import com.fx.media.domain.Media
 
 interface MediaCommandUseCase {
 
-    suspend fun uploadFile(mediaUploadCommand: MediaUploadCommand): Media
+    suspend fun uploadFile(mediaUploadCommand: MediaUploadCommand): List<Media>
 
-    fun uploadFileWithoutCoroutine(mediaUploadCommand: MediaUploadCommand): Media
 }

--- a/media/src/main/kotlin/com/fx/media/application/in/dto/MediaUploadCommand.kt
+++ b/media/src/main/kotlin/com/fx/media/application/in/dto/MediaUploadCommand.kt
@@ -4,7 +4,7 @@ import com.fx.media.adapter.`in`.web.dto.Context
 import org.springframework.web.multipart.MultipartFile
 
 data class MediaUploadCommand(
-    val file: MultipartFile,
+    val files: List<MultipartFile>,
     val context: Context,
     val userId: Long
 )

--- a/media/src/main/kotlin/com/fx/media/application/out/storage/FileStoragePort.kt
+++ b/media/src/main/kotlin/com/fx/media/application/out/storage/FileStoragePort.kt
@@ -1,11 +1,10 @@
 package com.fx.media.application.out.storage
 
-import com.fx.media.application.`in`.dto.MediaUploadCommand
+import com.fx.media.adapter.out.storage.dto.FileStoreCommand
 import com.fx.media.domain.Media
 
 interface FileStoragePort {
-    suspend fun store(mediaUploadCommand: MediaUploadCommand) : Media
 
-    fun storeWithoutCoroutine(mediaUploadCommand: MediaUploadCommand) : Media
+    suspend fun store(fileStoreCommand: FileStoreCommand) : Media
 
 }

--- a/media/src/main/kotlin/com/fx/media/application/service/MediaCommandService.kt
+++ b/media/src/main/kotlin/com/fx/media/application/service/MediaCommandService.kt
@@ -1,10 +1,13 @@
 package com.fx.media.application.service
 
+import com.fx.media.adapter.out.storage.dto.FileStoreCommand
 import com.fx.media.application.`in`.MediaCommandUseCase
 import com.fx.media.application.`in`.dto.MediaUploadCommand
 import com.fx.media.application.out.persistence.MediaPersistencePort
 import com.fx.media.application.out.storage.FileStoragePort
 import com.fx.media.domain.Media
+import com.fx.media.exception.MediaException
+import com.fx.media.exception.errorcode.MediaErrorCode
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,19 +16,20 @@ class MediaCommandService(
     private val fileStoragePort: FileStoragePort
 ) : MediaCommandUseCase {
 
-    override suspend fun uploadFile(mediaUploadCommand: MediaUploadCommand): Media {
+    override suspend fun uploadFile(mediaUploadCommand: MediaUploadCommand): List<Media> {
+        validateFileCount(mediaUploadCommand.files.size)
 
-        val media = fileStoragePort.store(mediaUploadCommand)
-        val savedMedia = mediaPersistencePort.save(media)
+        val medias = mediaUploadCommand.files.map { fileStoragePort.store(FileStoreCommand.storeFile(it, mediaUploadCommand.context, mediaUploadCommand.userId)) }
+        val savedMedia = medias.map { mediaPersistencePort.save(it) }
 
         return savedMedia
     }
 
-    override fun uploadFileWithoutCoroutine(mediaUploadCommand: MediaUploadCommand): Media {
-        val media = fileStoragePort.storeWithoutCoroutine(mediaUploadCommand)
-        val savedMedia = mediaPersistencePort.save(media)
-
-        return savedMedia
+    private fun validateFileCount(count: Int) {
+        if (count <= 0)
+            throw MediaException(MediaErrorCode.FILE_NOT_FOUND)
+        if (count > 5)
+            throw MediaException(MediaErrorCode.TOO_MANY_FILE)
     }
 
 }

--- a/media/src/main/kotlin/com/fx/media/exception/MediaException.kt
+++ b/media/src/main/kotlin/com/fx/media/exception/MediaException.kt
@@ -1,0 +1,8 @@
+package com.fx.media.exception
+
+import com.fx.global.api.ErrorCodeIfs
+
+class MediaException(
+    val errorCodeIfs: ErrorCodeIfs,
+    cause: Throwable? = null
+) : RuntimeException(errorCodeIfs.message, cause)

--- a/media/src/main/kotlin/com/fx/media/exception/errorcode/MediaErrorCode.kt
+++ b/media/src/main/kotlin/com/fx/media/exception/errorcode/MediaErrorCode.kt
@@ -1,0 +1,17 @@
+package com.fx.media.exception.errorcode
+
+import com.fx.global.api.ErrorCodeIfs
+import org.springframework.http.HttpStatus
+
+enum class MediaErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCodeIfs
+{
+
+    FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "업로드할 파일이 필요합니다."),
+    TOO_MANY_FILE(HttpStatus.BAD_REQUEST, "최대 5개의 파일만 업로드할 수 있습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장에 실패했습니다."),
+    DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "디렉터리 생성에 실패하였습니다.")
+
+}

--- a/media/src/main/kotlin/com/fx/media/exception/handler/MediaExceptionHandler.kt
+++ b/media/src/main/kotlin/com/fx/media/exception/handler/MediaExceptionHandler.kt
@@ -1,0 +1,22 @@
+package com.fx.media.exception.handler
+
+import com.fx.global.api.Api
+import com.fx.global.api.ErrorCodeIfs
+import com.fx.media.exception.MediaException
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class MediaExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(MediaExceptionHandler::class.java)
+
+    @ExceptionHandler(MediaException::class)
+    fun handleMediaException(e: MediaException): ResponseEntity<Api<ErrorCodeIfs>> {
+        log.error("", e)
+        return Api.ERROR(e.errorCodeIfs)
+    }
+
+}


### PR DESCRIPTION
refactor: 파일 업로드 로직 리팩토링

- FileStoreCommand 추가
- MediaUploadCommand의 MultipartFile객체의 단일 객체 -> 배열로 변경
- 예외 추가