### PR TITLE
feat: 모든 게시글 조회하는 Api에 MediaUrls값 추가

### DIFF
--- a/media/src/main/java/com/fx/media/adapter/out/persistence/repository/MediaRepository.java
+++ b/media/src/main/java/com/fx/media/adapter/out/persistence/repository/MediaRepository.java
@@ -3,10 +3,13 @@ package com.fx.media.adapter.out.persistence.repository;
 import com.fx.media.adapter.out.persistence.entity.MediaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MediaRepository extends JpaRepository<MediaEntity, Long> {
 
     Optional<MediaEntity> findByIdAndIsDeleted(Long id, boolean isDeleted);
+
+    List<MediaEntity> findByIdInAndIsDeleted(List<Long> ids, boolean isDeleted);
 
 }

--- a/media/src/main/kotlin/com/fx/media/adapter/in/web/MediaInternalApiAdapter.kt
+++ b/media/src/main/kotlin/com/fx/media/adapter/in/web/MediaInternalApiAdapter.kt
@@ -1,0 +1,23 @@
+package com.fx.media.adapter.`in`.web
+
+import com.fx.global.annotation.hexagonal.WebInputAdapter
+import com.fx.media.adapter.`in`.web.dto.MediaUrlResponse
+import com.fx.media.application.`in`.MediaQueryUseCase
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@WebInputAdapter
+@RequestMapping("/internal")
+class MediaInternalApiAdapter(
+    private val mediaQueryUseCase: MediaQueryUseCase
+) {
+    @GetMapping("/url")
+    fun getMediaUrl(
+        @RequestParam mediaIds: List<Long>
+    ) : ResponseEntity<List<MediaUrlResponse>> {
+
+        return ResponseEntity.ok(mediaQueryUseCase.getUrl(mediaIds).map { MediaUrlResponse( it.id!!, it.fileUrl )})
+    }
+}

--- a/media/src/main/kotlin/com/fx/media/adapter/in/web/dto/MediaUrlResponse.kt
+++ b/media/src/main/kotlin/com/fx/media/adapter/in/web/dto/MediaUrlResponse.kt
@@ -1,0 +1,6 @@
+package com.fx.media.adapter.`in`.web.dto
+
+data class MediaUrlResponse(
+    val mediaId: Long,
+    val mediaUrl: String?
+)

--- a/media/src/main/kotlin/com/fx/media/adapter/out/persistence/MediaPersistenceAdapter.kt
+++ b/media/src/main/kotlin/com/fx/media/adapter/out/persistence/MediaPersistenceAdapter.kt
@@ -20,4 +20,8 @@ class MediaPersistenceAdapter(
     override fun delete(media: Media) {
         mediaRepository.save(MediaEntity.from(media)).toDomain()
     }
+
+    override fun findByIdInAndIsDeleted(mediaIds: List<Long>): List<Media> =
+        mediaRepository.findByIdInAndIsDeleted(mediaIds, false).map { it.toDomain() }
+
 }

--- a/media/src/main/kotlin/com/fx/media/application/in/MediaQueryUseCase.kt
+++ b/media/src/main/kotlin/com/fx/media/application/in/MediaQueryUseCase.kt
@@ -6,4 +6,6 @@ interface MediaQueryUseCase {
 
     fun getFile(mediaId: Long) : Media
 
+    fun getUrl(mediaIds: List<Long>) : List<Media>
+
 }

--- a/media/src/main/kotlin/com/fx/media/application/out/persistence/MediaPersistencePort.kt
+++ b/media/src/main/kotlin/com/fx/media/application/out/persistence/MediaPersistencePort.kt
@@ -10,4 +10,6 @@ interface MediaPersistencePort {
 
     fun delete(media: Media)
 
+    fun findByIdInAndIsDeleted(mediaIds: List<Long>) : List<Media>
+
 }

--- a/media/src/main/kotlin/com/fx/media/application/service/MediaQueryService.kt
+++ b/media/src/main/kotlin/com/fx/media/application/service/MediaQueryService.kt
@@ -2,7 +2,6 @@ package com.fx.media.application.service
 
 import com.fx.media.application.`in`.MediaQueryUseCase
 import com.fx.media.application.out.persistence.MediaPersistencePort
-import com.fx.media.application.out.storage.FileStoragePort
 import com.fx.media.domain.Media
 import com.fx.media.exception.MediaException
 import com.fx.media.exception.errorcode.MediaErrorCode
@@ -11,10 +10,13 @@ import org.springframework.stereotype.Service
 @Service
 class MediaQueryService(
     private val mediaPersistencePort: MediaPersistencePort,
-    private val fileStoragePort: FileStoragePort
 ) : MediaQueryUseCase {
 
     override fun getFile(mediaId: Long): Media =
         mediaPersistencePort.findByIdAndIsDeleted(mediaId) ?: throw MediaException(MediaErrorCode.MEDIA_NOT_FOUND)
+
+
+    override fun getUrl(mediaIds: List<Long>): List<Media> =
+        mediaPersistencePort.findByIdInAndIsDeleted(mediaIds)
 
 }

--- a/media/src/main/kotlin/com/fx/media/config/web/WebConfig.kt
+++ b/media/src/main/kotlin/com/fx/media/config/web/WebConfig.kt
@@ -24,7 +24,7 @@ class WebConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(authorizationInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/open-api/**")
+            .excludePathPatterns("/open-api/**", "/internal/**")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {

--- a/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostMediaRepository.java
+++ b/post/src/main/java/com/fx/post/adapter/out/persistence/repository/PostMediaRepository.java
@@ -11,4 +11,6 @@ public interface PostMediaRepository extends JpaRepository<PostMediaEntity, Long
 
     void deleteByPostIdAndMediaId(Long postId, Long mediaId);
 
+    List<PostMediaEntity> findByPostIdIn(List<Long> postIds);
+
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/PostApiAdapter.kt
@@ -7,6 +7,7 @@ import com.fx.global.resolver.AuthUser
 import com.fx.post.adapter.`in`.web.dto.*
 import com.fx.post.application.`in`.PostCommandUseCase
 import com.fx.post.application.`in`.PostQueryUseCase
+import com.fx.post.application.out.web.MediaWebPort
 import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
@@ -17,7 +18,8 @@ import java.time.LocalDateTime
 @RequestMapping("/api/v1/posts")
 class PostApiAdapter(
     private val postCommandUseCase: PostCommandUseCase,
-    private val postQueryUseCase: PostQueryUseCase
+    private val postQueryUseCase: PostQueryUseCase,
+    private val mediaWebPort: MediaWebPort
 ) {
     @PostMapping
     fun createPost(
@@ -62,4 +64,5 @@ class PostApiAdapter(
         val post = postCommandUseCase.updatePost(postId, postUpdateRequest.toCommand(authUser))
         return Api.OK(PostUpdateResponse(post.id))
     }
+
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostResponse.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/in/web/dto/PostResponse.kt
@@ -9,7 +9,7 @@ data class PostResponse(
     //val nickname: String,
     //val profileImageUrl: String? = null,
     val content: String?,
-    //val mediaUrls: List<String>,
+    val mediaUrls: List<String>?= null,
     val createdAt: LocalDateTime,
     val likeCount: Long,
     val commentCount: Long
@@ -20,6 +20,7 @@ data class PostResponse(
                 postId = postSummaryDto.id,
                 userId = postSummaryDto.userId,
                 content = postSummaryDto.content,
+                mediaUrls = postSummaryDto.mediaUrls,
                 createdAt = postSummaryDto.createdAt,
                 likeCount = postSummaryDto.likeCount,
                 commentCount = postSummaryDto.commentCount

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/PostMediaPersistenceAdapter.kt
@@ -20,4 +20,7 @@ class PostMediaPersistenceAdapter(
     override fun delete(postId: Long, mediaId: Long) =
         postMediaRepository.deleteByPostIdAndMediaId(postId, mediaId)
 
+    override fun findByPostIdIn(postIds: List<Long>): List<PostMedia> =
+        postMediaRepository.findByPostIdIn(postIds).map { it.toDomain() }
+
 }

--- a/post/src/main/kotlin/com/fx/post/adapter/out/persistence/dto/PostSummaryDto.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/persistence/dto/PostSummaryDto.kt
@@ -6,7 +6,11 @@ data class PostSummaryDto(
     var id: Long,
     val userId: Long,
     val content: String,
+    var mediaUrls: List<String>?= null,
     val createdAt: LocalDateTime,
     val likeCount: Long,
     val commentCount: Long,
-)
+) {
+    constructor(id: Long, userId: Long, content: String, createdAt: LocalDateTime, likeCount: Long, commentCount: Long)
+            : this(id, userId, content, null, createdAt, likeCount, commentCount)
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/client/MediaFeignClient.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/client/MediaFeignClient.kt
@@ -1,0 +1,13 @@
+package com.fx.post.adapter.out.web.client
+
+import com.fx.post.adapter.out.web.impl.dto.MediaUrlResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "media-service", path = "/internal")
+interface MediaFeignClient {
+    @GetMapping("/url")
+    fun getUrl(@RequestParam mediaIds: List<Long>): ResponseEntity<List<MediaUrlResponse>>
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/MediaWebAdapter.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/MediaWebAdapter.kt
@@ -1,0 +1,17 @@
+package com.fx.post.adapter.out.web.impl
+
+import com.fx.global.annotation.hexagonal.WebOutputAdapter
+import com.fx.post.adapter.out.web.client.MediaFeignClient
+import com.fx.post.adapter.out.web.impl.dto.MediaUrlCommand
+import com.fx.post.adapter.out.web.impl.dto.MediaUrlResponse
+import com.fx.post.application.out.web.MediaWebPort
+
+@WebOutputAdapter
+class MediaWebAdapter(
+    private val mediaFeignClient: MediaFeignClient,
+) : MediaWebPort {
+
+    override fun getUrl(mediaIds: List<Long>): List<MediaUrlCommand>? =
+        mediaFeignClient.getUrl(mediaIds).body?.map { MediaUrlResponse.toCommand(it) }
+
+}

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/dto/MediaUrlCommand.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/dto/MediaUrlCommand.kt
@@ -1,0 +1,7 @@
+package com.fx.post.adapter.out.web.impl.dto
+
+data class MediaUrlCommand(
+    val mediaId: Long,
+    val mediaUrl: String
+
+)

--- a/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/dto/MediaUrlResponse.kt
+++ b/post/src/main/kotlin/com/fx/post/adapter/out/web/impl/dto/MediaUrlResponse.kt
@@ -1,0 +1,15 @@
+package com.fx.post.adapter.out.web.impl.dto
+
+data class MediaUrlResponse(
+    val mediaId: Long,
+    val mediaUrl: String
+) {
+    companion object {
+        fun toCommand(mediaUrlResponse: MediaUrlResponse): MediaUrlCommand {
+            return MediaUrlCommand(
+                mediaId = mediaUrlResponse.mediaId,
+                mediaUrl = mediaUrlResponse.mediaUrl
+            )
+        }
+    }
+}

--- a/post/src/main/kotlin/com/fx/post/application/out/persistence/PostMediaPersistencePort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/persistence/PostMediaPersistencePort.kt
@@ -10,4 +10,5 @@ interface PostMediaPersistencePort {
 
     fun delete(postId:Long, mediaId:Long)
 
+    fun findByPostIdIn(postIds: List<Long>): List<PostMedia>
 }

--- a/post/src/main/kotlin/com/fx/post/application/out/web/MediaWebPort.kt
+++ b/post/src/main/kotlin/com/fx/post/application/out/web/MediaWebPort.kt
@@ -1,0 +1,9 @@
+package com.fx.post.application.out.web
+
+import com.fx.post.adapter.out.web.impl.dto.MediaUrlCommand
+
+interface MediaWebPort {
+
+    fun getUrl(mediaIds: List<Long>): List<MediaUrlCommand>?
+
+}

--- a/post/src/main/kotlin/com/fx/post/application/service/LikeQueryService.kt
+++ b/post/src/main/kotlin/com/fx/post/application/service/LikeQueryService.kt
@@ -3,13 +3,17 @@ package com.fx.post.application.service
 import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.application.`in`.LikeQueryUseCase
 import com.fx.post.application.out.persistence.LikePersistencePort
+import com.fx.post.application.out.persistence.PostMediaPersistencePort
 import com.fx.post.application.out.persistence.PostPersistencePort
+import com.fx.post.application.out.web.MediaWebPort
 import org.springframework.stereotype.Service
 
 @Service
 class LikeQueryService(
     private val likePersistencePort: LikePersistencePort,
-    private val postPersistencePort: PostPersistencePort
+    private val postPersistencePort: PostPersistencePort,
+    private val postMediaPersistencePort: PostMediaPersistencePort,
+    private val mediaWebPort: MediaWebPort
 ) : LikeQueryUseCase{
 
     override fun getLikeUsers(postId: Long): List<Long> {
@@ -22,9 +26,34 @@ class LikeQueryService(
 
     override fun getMyLikedPosts(userId: Long, postId: Long): List<PostSummaryDto> {
         val posts = postPersistencePort.findLikedPostsByUserIdAndPostIdBeforeAndIsDeleted(userId, postId)
+
+        val mappedList = mappedByMediaUrls(posts)
         // 유저 모듈에서 FeignClient로 userId들의 닉네임들 가져온 뒤 매핑하기(미구현)
 
-        return posts
+        return mappedList
+    }
+
+    private fun mappedByMediaUrls(posts: List<PostSummaryDto>): List<PostSummaryDto> {
+        if (posts.isEmpty()) return emptyList()
+
+        val postIds = posts.map { it.id }
+
+        val postToMediaIds = postMediaPersistencePort
+            .findByPostIdIn(postIds)
+            .groupBy({ it.postId }, { it.mediaId })
+
+        val mediaUrls = mediaWebPort
+            .getUrl(postToMediaIds.values.flatten())
+            .orEmpty()
+            .associate { it.mediaId to it.mediaUrl }
+
+        return posts.map { post ->
+            val urls = postToMediaIds[post.id]
+                ?.mapNotNull(mediaUrls::get)
+                .orEmpty()
+
+            post.copy(mediaUrls = urls)
+        }
     }
 
 }

--- a/post/src/main/kotlin/com/fx/post/application/service/PostQueryService.kt
+++ b/post/src/main/kotlin/com/fx/post/application/service/PostQueryService.kt
@@ -2,32 +2,66 @@ package com.fx.post.application.service
 
 import com.fx.post.adapter.out.persistence.dto.PostSummaryDto
 import com.fx.post.application.`in`.PostQueryUseCase
+import com.fx.post.application.out.persistence.PostMediaPersistencePort
 import com.fx.post.application.out.persistence.PostPersistencePort
+import com.fx.post.application.out.web.MediaWebPort
 import org.springframework.stereotype.Service
 
 @Service
 class PostQueryService(
     private val postPersistencePort: PostPersistencePort,
+    private val postMediaPersistencePort: PostMediaPersistencePort,
+    private val mediaWebPort: MediaWebPort
     ) : PostQueryUseCase {
 
     override fun getFollowersPosts(userId: Long, postId: Long): List<PostSummaryDto> {
         // 유저 모듈에서 FeignClient로 팔로우 리스트 가져오기(미구현)
         val followers = listOf(1L, 2L) // 임시 구현
         val posts = postPersistencePort.findByUserIdAndPostIdBeforeAndIsDeleted(followers, postId)
+
+        val mappedList = mappedByMediaUrls(posts)
+
         // 유저 모듈에서 FeignClient로 follower들의 닉네임을 가져온 뒤 매핑하기(미구현)
-        return posts
+        return mappedList
     }
 
     override fun getMyPosts(userId: Long, postId: Long): List<PostSummaryDto> {
         val posts = postPersistencePort.findByUserIdAndPostIdBeforeAndIsDeleted(listOf(userId), postId)
+
+        val mappedList = mappedByMediaUrls(posts)
         // 유저 모듈에서 FeignClient로 userId들의 닉네임들 가져온 뒤 매핑하기(미구현)
-        return posts
+        return mappedList
     }
 
     override fun getUserPosts(userId: Long, postId: Long): List<PostSummaryDto> {
         val posts = postPersistencePort.findByUserIdAndPostIdBeforeAndIsDeleted(listOf(userId), postId)
+
+        val mappedList = mappedByMediaUrls(posts)
         // 유저 모듈에서 FeignClient로 userId들의 닉네임들 가져온 뒤 매핑하기(미구현)
-        return posts
+        return mappedList
+    }
+
+    private fun mappedByMediaUrls(posts: List<PostSummaryDto>): List<PostSummaryDto> {
+        if (posts.isEmpty()) return emptyList()
+
+        val postIds = posts.map { it.id }
+
+        val postToMediaIds = postMediaPersistencePort
+            .findByPostIdIn(postIds)
+            .groupBy({ it.postId }, { it.mediaId })
+
+        val mediaUrls = mediaWebPort
+            .getUrl(postToMediaIds.values.flatten())
+            .orEmpty()
+            .associate { it.mediaId to it.mediaUrl }
+
+        return posts.map { post ->
+            val urls = postToMediaIds[post.id]
+                ?.mapNotNull(mediaUrls::get)
+                .orEmpty()
+
+            post.copy(mediaUrls = urls)
+        }
     }
 
 }


### PR DESCRIPTION
feat: 모든 게시글 조회하는 Api에 MediaUrls값 추가

- MediaId 리스트에 해당하는 Url값 조회하는 IntenalApi 추가
- MediaURL값 조회하는 FeignClient 추가
- 팔로워들의 게시글 조회에 mediaUrls 추가
- 내 게시글 조회에 mediaUrls 추가
- 특정 유저 게시글 조회에 mediaUrls 추가
- 좋아요한 게시글 조회에 mediaUrls 추가