### PR TITLE
feat: 팔로워/팔로잉 조회 API 개발 with querydsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 ### Ignore .env ###
 *.env
 
+## QueryDSL ###
+**/src/main/generated
+
 ### STS ###
 .apt_generated
 .classpath

--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 group = "com.fx"
 version = "0.0.1-SNAPSHOT"
+val queryDslVersion = "5.1.0"
 
 java {
     toolchain {
@@ -42,13 +43,18 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.session:spring-session-data-redis")
+    implementation ("com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta") // QueryDSL
     implementation(project(":global"))
 
     compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    annotationProcessor("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta") // QueryDSL
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api") // QueryDSL
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api") // QueryDSL
 
     runtimeOnly("com.mysql:mysql-connector-j")
 
-    annotationProcessor("org.projectlombok:lombok")
+
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
@@ -83,4 +89,23 @@ tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar
 
 tasks.getByName<Jar>("jar") {
     enabled = false
+}
+
+val querydslDir = "src/main/generated"
+
+sourceSets {
+    getByName("main").java.srcDirs(querydslDir)
+}
+
+tasks.withType<JavaCompile> {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+
+    // 위의 설정이 안되면 아래 설정 사용
+    // options.generatedSourceOutputDirectory.set(file(querydslDir))
+}
+
+tasks.named("clean") {
+    doLast {
+        file(querydslDir).deleteRecursively()
+    }
 }

--- a/user/src/main/java/com/fx/user/adapter/out/persistence/entity/FollowEntity.java
+++ b/user/src/main/java/com/fx/user/adapter/out/persistence/entity/FollowEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.jetbrains.annotations.NotNull;
 
 @Getter
 @Entity

--- a/user/src/main/java/com/fx/user/adapter/out/persistence/repository/FollowQueryRepository.java
+++ b/user/src/main/java/com/fx/user/adapter/out/persistence/repository/FollowQueryRepository.java
@@ -1,0 +1,104 @@
+package com.fx.user.adapter.out.persistence.repository;
+
+import com.fx.user.adapter.out.persistence.entity.FollowEntity;
+import com.fx.user.adapter.out.persistence.entity.ProfileEntity;
+import com.fx.user.adapter.out.persistence.entity.QFollowEntity;
+import com.fx.user.adapter.out.persistence.entity.QProfileEntity;
+import com.fx.user.domain.FollowQuery;
+import com.fx.user.domain.FollowUserInfo;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import static com.fx.user.adapter.out.persistence.entity.QFollowEntity.followEntity;
+import static com.fx.user.adapter.out.persistence.entity.QProfileEntity.profileEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    /**
+     * 내가 팔로우한 사용자 조회 (내가 followingId 를 참조)
+     */
+    public List<FollowUserInfo> findByFollowings(FollowQuery followQuery) {
+        return jpaQueryFactory
+            .select(Projections.constructor(
+                FollowUserInfo.class,
+                followEntity.id,
+                profileEntity.userId,
+                profileEntity.nickname,
+                profileEntity.mediaId,
+                followEntity.status,
+                followEntity.createdAt
+            ))
+            .from(followEntity)
+            .join(profileEntity).on(followEntity.followingId.eq(profileEntity.userId))
+            .where(
+                followEntity.followerId.eq(followQuery.getTargetUserId()),
+                ltCreatedAt(followQuery.getCreatedAt()),
+                likeNickname(followQuery.getNickname()),
+                followEntity.status.eq(followQuery.getStatus())
+            )
+            .orderBy(getOrderSpecifier(followQuery.getPageable().getSort()).toArray(new OrderSpecifier[0]))
+            .limit(followQuery.getPageable().getPageSize())
+            .fetch();
+    }
+
+    /**
+     * 나를 팔로우한 사용자 조회 (내가 followerId 를 참조)
+     */
+    public List<FollowUserInfo> findByFollowers(FollowQuery followQuery) {
+        return jpaQueryFactory
+            .select(Projections.constructor(
+                FollowUserInfo.class,
+                followEntity.id,
+                profileEntity.userId,
+                profileEntity.nickname,
+                profileEntity.mediaId.stringValue(),
+                followEntity.status,
+                followEntity.createdAt
+            ))
+            .from(followEntity)
+            .join(profileEntity).on(followEntity.followerId.eq(profileEntity.userId))
+            .where(
+                followEntity.followingId.eq(followQuery.getTargetUserId()),
+                ltCreatedAt(followQuery.getCreatedAt()),
+                likeNickname(followQuery.getNickname())
+            )
+            .orderBy(getOrderSpecifier(followQuery.getPageable().getSort()).toArray(new OrderSpecifier[0]))
+            .limit(followQuery.getPageable().getPageSize())
+            .fetch();
+    }
+
+    private BooleanExpression ltCreatedAt(LocalDateTime createdAt) {
+        return createdAt != null ? followEntity.createdAt.lt(createdAt) : null;
+    }
+
+    private BooleanExpression likeNickname(String nickname) {
+        return nickname != null && !nickname.isBlank()
+            ? profileEntity.nickname.containsIgnoreCase(nickname)
+            : null;
+    }
+
+    private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+        List<OrderSpecifier> orders = new ArrayList<>();
+        sort.stream().forEach(order -> {
+            PathBuilder orderByExpression = new PathBuilder(FollowEntity.class, "followEntity");
+            orders.add(new OrderSpecifier<>(order.isDescending() ? Order.DESC : Order.ASC,
+                orderByExpression.get(order.getProperty())));
+        });
+        return orders;
+    }
+
+}

--- a/user/src/main/java/com/fx/user/adapter/out/persistence/repository/FollowQueryRepository.java
+++ b/user/src/main/java/com/fx/user/adapter/out/persistence/repository/FollowQueryRepository.java
@@ -74,7 +74,8 @@ public class FollowQueryRepository {
             .where(
                 followEntity.followingId.eq(followQuery.getTargetUserId()),
                 ltCreatedAt(followQuery.getCreatedAt()),
-                likeNickname(followQuery.getNickname())
+                likeNickname(followQuery.getNickname()),
+                followEntity.status.eq(followQuery.getStatus())
             )
             .orderBy(getOrderSpecifier(followQuery.getPageable().getSort()).toArray(new OrderSpecifier[0]))
             .limit(followQuery.getPageable().getPageSize())

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/FollowApiAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/FollowApiAdapter.kt
@@ -50,6 +50,7 @@ class FollowApiAdapter(
             "팔로우 요청을 수락했습니다."
         )
 
+    // 예시 : /api/v1/follows/{targetUserId}/followings?sort=createdAt,DESC&size=20
     @GetMapping("/{userId}/followings")
     fun getUserFollowings(
         @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
@@ -57,7 +58,6 @@ class FollowApiAdapter(
         @ModelAttribute followSearchParam: FollowSearchParam,
         @PageableDefault(sort = ["createdAt"] , direction = Sort.Direction.DESC, size = 20) pageable: Pageable // DEFAULT : 최신순 조회
     ): ResponseEntity<Api<List<FollowUserResponse>>> {
-
         val followUserInfoList = followCommandUseCase.getUserFollowings(
             followSearchParam.toCommand(
                 authenticatedUser.userId,
@@ -65,9 +65,25 @@ class FollowApiAdapter(
                 pageable
             )
         )
-
         return Api.OK(FollowUserResponse.from(followUserInfoList))
-
     }
+
+    @GetMapping("/{userId}/followers")
+    fun getUserFollowers(
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+        @PathVariable userId: Long,
+        @ModelAttribute followSearchParam: FollowSearchParam,
+        @PageableDefault(sort = ["createdAt"] , direction = Sort.Direction.DESC, size = 20) pageable: Pageable // DEFAULT : 최신순 조회
+    ): ResponseEntity<Api<List<FollowUserResponse>>> {
+        val followUserInfoList = followCommandUseCase.getUserFollowers(
+            followSearchParam.toCommand(
+                authenticatedUser.userId,
+                userId,
+                pageable
+            )
+        )
+        return Api.OK(FollowUserResponse.from(followUserInfoList))
+    }
+
 
 }

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/FollowApiAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/FollowApiAdapter.kt
@@ -3,11 +3,18 @@ package com.fx.user.adapter.`in`.web
 import com.fx.global.annotation.hexagonal.WebInputAdapter
 import com.fx.global.api.Api
 import com.fx.user.adapter.`in`.web.dto.follow.FollowResponse
+import com.fx.user.adapter.`in`.web.dto.follow.FollowSearchParam
+import com.fx.user.adapter.`in`.web.dto.follow.FollowUserResponse
 import com.fx.user.adapter.security.dto.AuthenticatedUser
 import com.fx.user.application.`in`.FollowCommandUseCase
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -42,5 +49,25 @@ class FollowApiAdapter(
             followCommandUseCase.approveFollowUser(authenticatedUser.userId, followId)),
             "팔로우 요청을 수락했습니다."
         )
+
+    @GetMapping("/{userId}/followings")
+    fun getUserFollowings(
+        @AuthenticationPrincipal authenticatedUser: AuthenticatedUser,
+        @PathVariable userId: Long,
+        @ModelAttribute followSearchParam: FollowSearchParam,
+        @PageableDefault(sort = ["createdAt"] , direction = Sort.Direction.DESC, size = 20) pageable: Pageable // DEFAULT : 최신순 조회
+    ): ResponseEntity<Api<List<FollowUserResponse>>> {
+
+        val followUserInfoList = followCommandUseCase.getUserFollowings(
+            followSearchParam.toCommand(
+                authenticatedUser.userId,
+                userId,
+                pageable
+            )
+        )
+
+        return Api.OK(FollowUserResponse.from(followUserInfoList))
+
+    }
 
 }

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/follow/FollowSearchParam.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/follow/FollowSearchParam.kt
@@ -1,0 +1,23 @@
+package com.fx.user.adapter.`in`.web.dto.follow
+
+import com.fx.user.application.`in`.dto.FollowQueryCommand
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+data class FollowSearchParam(
+    val followId: Long? = null,
+    val createdAt: LocalDateTime? = null,
+    val nickname: String? = null
+) {
+
+    fun toCommand(requestUserId: Long, targetUserId: Long, pageable: Pageable): FollowQueryCommand =
+        FollowQueryCommand(
+            requestUserId = requestUserId,
+            targetUserId = targetUserId,
+            followId = this.followId,
+            createdAt = this.createdAt,
+            nickname = this.nickname,
+            pageable = pageable
+        )
+
+}

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/follow/FollowUserResponse.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/follow/FollowUserResponse.kt
@@ -1,0 +1,31 @@
+package com.fx.user.adapter.`in`.web.dto.follow
+
+import com.fx.user.domain.FollowStatus
+import com.fx.user.domain.FollowUserInfo
+import java.time.LocalDateTime
+
+data class FollowUserResponse(
+    val followId: Long,
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String,
+    val status: FollowStatus,
+    val followCreatedAt: LocalDateTime
+) {
+
+    companion object {
+        @JvmStatic
+        fun from(followUserInfoList: List<FollowUserInfo>): List<FollowUserResponse> =
+            followUserInfoList.map { info ->
+                FollowUserResponse(
+                    followId = info.followId,
+                    userId = info.userId,
+                    nickname = info.nickname,
+                    profileImageUrl = "", //TODO mediaId 기반 URL 로 변경해야 함
+                    status = info.status,
+                    followCreatedAt = info.followCreatedAt
+                )
+            }
+    }
+
+}

--- a/user/src/main/kotlin/com/fx/user/adapter/out/persistence/FollowPersistenceAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/persistence/FollowPersistenceAdapter.kt
@@ -40,4 +40,7 @@ class FollowPersistenceAdapter(
     override fun getUserFollowings(followQuery: FollowQuery): List<FollowUserInfo> =
         followQueryRepository.findByFollowings(followQuery)
 
+    override fun getUserFollowers(followQuery: FollowQuery): List<FollowUserInfo> =
+        followQueryRepository.findByFollowers(followQuery)
+
 }

--- a/user/src/main/kotlin/com/fx/user/adapter/out/persistence/FollowPersistenceAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/persistence/FollowPersistenceAdapter.kt
@@ -2,14 +2,18 @@ package com.fx.user.adapter.out.persistence
 
 import com.fx.global.annotation.hexagonal.PersistenceAdapter
 import com.fx.user.adapter.out.persistence.entity.FollowEntity
+import com.fx.user.adapter.out.persistence.repository.FollowQueryRepository
 import com.fx.user.adapter.out.persistence.repository.FollowRepository
 import com.fx.user.application.out.FollowPersistencePort
 import com.fx.user.domain.Follow
+import com.fx.user.domain.FollowQuery
 import com.fx.user.domain.FollowStatus
+import com.fx.user.domain.FollowUserInfo
 
 @PersistenceAdapter
 class FollowPersistenceAdapter(
-    private val followRepository: FollowRepository
+    private val followRepository: FollowRepository,
+    private val followQueryRepository: FollowQueryRepository
 ) : FollowPersistencePort {
 
     override fun saveFollow(follow: Follow): Follow =
@@ -32,5 +36,8 @@ class FollowPersistenceAdapter(
 
     override fun deleteFollow(followId: Long) =
         followRepository.deleteById(followId)
+
+    override fun getUserFollowings(followQuery: FollowQuery): List<FollowUserInfo> =
+        followQueryRepository.findByFollowings(followQuery)
 
 }

--- a/user/src/main/kotlin/com/fx/user/application/in/FollowCommandUseCase.kt
+++ b/user/src/main/kotlin/com/fx/user/application/in/FollowCommandUseCase.kt
@@ -1,6 +1,8 @@
 package com.fx.user.application.`in`
 
+import com.fx.user.application.`in`.dto.FollowQueryCommand
 import com.fx.user.domain.Follow
+import com.fx.user.domain.FollowUserInfo
 
 interface FollowCommandUseCase {
 
@@ -9,5 +11,7 @@ interface FollowCommandUseCase {
     fun unfollowUser(requestUserId: Long, followId: Long): Boolean
 
     fun approveFollowUser(userId: Long, followId: Long): Follow
+
+    fun getUserFollowings(followQueryCommand: FollowQueryCommand): List<FollowUserInfo>
 
 }

--- a/user/src/main/kotlin/com/fx/user/application/in/FollowCommandUseCase.kt
+++ b/user/src/main/kotlin/com/fx/user/application/in/FollowCommandUseCase.kt
@@ -14,4 +14,6 @@ interface FollowCommandUseCase {
 
     fun getUserFollowings(followQueryCommand: FollowQueryCommand): List<FollowUserInfo>
 
+    fun getUserFollowers(followQueryCommand: FollowQueryCommand): List<FollowUserInfo>
+
 }

--- a/user/src/main/kotlin/com/fx/user/application/in/dto/FollowQueryCommand.kt
+++ b/user/src/main/kotlin/com/fx/user/application/in/dto/FollowQueryCommand.kt
@@ -1,0 +1,15 @@
+package com.fx.user.application.`in`.dto
+
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+data class FollowQueryCommand(
+    val requestUserId: Long,
+    val targetUserId: Long,
+
+    val followId: Long?,
+    val createdAt: LocalDateTime?,
+    val nickname: String?,
+
+    val pageable: Pageable
+)

--- a/user/src/main/kotlin/com/fx/user/application/out/FollowPersistencePort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/out/FollowPersistencePort.kt
@@ -23,4 +23,6 @@ interface FollowPersistencePort {
 
     fun getUserFollowings(followQuery: FollowQuery): List<FollowUserInfo>
 
+    fun getUserFollowers(followQuery: FollowQuery): List<FollowUserInfo>
+
 }

--- a/user/src/main/kotlin/com/fx/user/application/out/FollowPersistencePort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/out/FollowPersistencePort.kt
@@ -1,7 +1,9 @@
 package com.fx.user.application.out
 
 import com.fx.user.domain.Follow
+import com.fx.user.domain.FollowQuery
 import com.fx.user.domain.FollowStatus
+import com.fx.user.domain.FollowUserInfo
 
 interface FollowPersistencePort {
 
@@ -18,5 +20,7 @@ interface FollowPersistencePort {
     fun getFollow(followId: Long): Follow?
 
     fun deleteFollow(followId: Long)
+
+    fun getUserFollowings(followQuery: FollowQuery): List<FollowUserInfo>
 
 }

--- a/user/src/main/kotlin/com/fx/user/config/jackson/JacksonConfig.kt
+++ b/user/src/main/kotlin/com/fx/user/config/jackson/JacksonConfig.kt
@@ -1,0 +1,23 @@
+package com.fx.user.config.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class JacksonConfig {
+
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        return ObjectMapper().apply {
+            registerKotlinModule()
+            registerModule(JavaTimeModule())
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
+    }
+
+}

--- a/user/src/main/kotlin/com/fx/user/config/querydsl/QuerydslConfig.kt
+++ b/user/src/main/kotlin/com/fx/user/config/querydsl/QuerydslConfig.kt
@@ -1,0 +1,17 @@
+package com.fx.user.config.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig(
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory =
+        JPAQueryFactory(entityManager)
+
+}

--- a/user/src/main/kotlin/com/fx/user/domain/FollowQuery.kt
+++ b/user/src/main/kotlin/com/fx/user/domain/FollowQuery.kt
@@ -1,0 +1,30 @@
+package com.fx.user.domain
+
+import com.fx.user.application.`in`.dto.FollowQueryCommand
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+data class FollowQuery(
+    val targetUserId: Long,
+
+    val followId: Long? = null,
+    val createdAt: LocalDateTime? = null,
+    val nickname: String? = null,
+    val pageable: Pageable,
+
+    val status: FollowStatus
+) {
+    companion object {
+        @JvmStatic
+        fun searchCondition(followQueryCommand: FollowQueryCommand, status: FollowStatus): FollowQuery {
+            return FollowQuery(
+                targetUserId = followQueryCommand.targetUserId,
+                followId = followQueryCommand.followId,
+                createdAt = followQueryCommand.createdAt,
+                nickname = followQueryCommand.nickname,
+                pageable = followQueryCommand.pageable,
+                status = status
+            )
+        }
+    }
+}

--- a/user/src/main/kotlin/com/fx/user/domain/FollowUserInfo.kt
+++ b/user/src/main/kotlin/com/fx/user/domain/FollowUserInfo.kt
@@ -1,0 +1,12 @@
+package com.fx.user.domain
+
+import java.time.LocalDateTime
+
+data class FollowUserInfo(
+    val followId: Long,
+    val userId: Long,
+    val nickname: String,
+    val mediaId: Long?,
+    val status: FollowStatus,
+    val followCreatedAt: LocalDateTime
+)

--- a/user/src/main/kotlin/com/fx/user/exception/errorcode/FollowErrorCode.kt
+++ b/user/src/main/kotlin/com/fx/user/exception/errorcode/FollowErrorCode.kt
@@ -12,6 +12,7 @@ enum class FollowErrorCode(
     FOLLOW_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, "이미 팔로우 요청을 보냈습니다."),
     SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우/팔로워 요청을 찾을 수 없습니다."),
-    UNAUTHORIZED_UNFOLLOW(HttpStatus.UNAUTHORIZED, "팔로우/팔로워 삭제 권한이 없습니다.")
+    UNAUTHORIZED_UNFOLLOW(HttpStatus.UNAUTHORIZED, "팔로우/팔로워 삭제 권한이 없습니다."),
+    UNAUTHORIZED_FOLLOW_LIST_ACCESS(HttpStatus.UNAUTHORIZED, "팔로우/팔로워 조회 권한이 잆습니다.")
 
 }


### PR DESCRIPTION
# feat: 팔로워/팔로잉 조회 API 개발 with querydsl

- private 계정을 조회하려는 경우, 팔로잉 되어 있지 않으면 예외