### PR TITLE
fix: URL Mapping 오류 해결

### DIFF
--- a/user/src/main/kotlin/com/fx/user/application/out/persistence/dto/FollowUserInfo.kt
+++ b/user/src/main/kotlin/com/fx/user/application/out/persistence/dto/FollowUserInfo.kt
@@ -9,6 +9,5 @@ data class FollowUserInfo @JvmOverloads constructor (
     val nickname: String,
     val status: FollowStatus,
     val followCreatedAt: LocalDateTime,
-    val mediaId: Long? = null,
     val profileImageUrl: String? = null,
 )

--- a/user/src/main/kotlin/com/fx/user/application/service/FollowQueryService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/FollowQueryService.kt
@@ -70,7 +70,6 @@ class FollowQueryService(
         }
     }
 
-
     private fun mapMediaUrls(followUserInfoList: List<FollowUserInfo>): List<FollowUserInfo> {
 
         val referenceIdList: List<Long> = followUserInfoList.mapNotNull { it.userId }
@@ -85,7 +84,7 @@ class FollowQueryService(
 
         return followUserInfoList.map { user ->
             user.copy(
-                profileImageUrl = user.mediaId?.let { mediaUrlMap[it] }
+                profileImageUrl = mediaUrlMap[user.userId]
             )
         }
     }


### PR DESCRIPTION
# fix: URL Mapping 오류 해결

- 사용하지 않는 `mediaId` 필드 제거

```
       return followUserInfoList.map { user ->
            user.copy(
                profileImageUrl = user.mediaId?.let { mediaUrlMap[it] }
            )
```
mediaId 는 항상 null 이기 때문에 `mediaUrlMap[it]` 매핑 불가


```
        return followUserInfoList.map { user ->
            user.copy(
                profileImageUrl = mediaUrlMap[user.userId]
            )
        }
```
위와 같이 변경