### PR TITLE
feat: 회원가입 Email 인증 API 개발

### DIFF
--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 
+    // Coroutine
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.3")
+
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")

--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -37,15 +37,22 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+
+    // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+
+    // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.session:spring-session-data-redis")
-    implementation ("com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta") // QueryDSL
+
     implementation(project(":global"))
+
+    // E-Mail
+    implementation("org.springframework.boot:spring-boot-starter-mail")
 
     // Prometheus
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -58,13 +65,14 @@ dependencies {
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
-    annotationProcessor("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta") // QueryDSL
-    annotationProcessor("jakarta.annotation:jakarta.annotation-api") // QueryDSL
-    annotationProcessor("jakarta.persistence:jakarta.persistence-api") // QueryDSL
+
+    // QueryDSL
+    implementation("com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
     runtimeOnly("com.mysql:mysql-connector-j")
-
-
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/EmailVerificationOpenApiAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/EmailVerificationOpenApiAdapter.kt
@@ -1,0 +1,29 @@
+package com.fx.user.adapter.`in`.web
+
+import com.fx.global.annotation.hexagonal.WebInputAdapter
+import com.fx.global.api.Api
+import com.fx.user.adapter.`in`.web.dto.user.EmailRequest
+import com.fx.user.application.port.`in`.EmailVerificationUseCase
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@WebInputAdapter
+@RequestMapping("/open-api/v1/email")
+class EmailVerificationOpenApiAdapter(
+    private val emailVerificationUseCase: EmailVerificationUseCase
+) {
+
+    @PostMapping
+    @Operation(summary = "이메일 인증", description = "회원가입 전 이메일 인증을 진행합니다.")
+    fun sendVerificationCode(
+        @RequestBody @Valid emailRequest: EmailRequest
+    ): ResponseEntity<Api<Boolean>> =
+        Api.OK(emailVerificationUseCase.sendVerificationCode(emailRequest.email), "인증코드가 발송되었습니다.")
+
+
+
+}

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/EmailVerificationOpenApiAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/EmailVerificationOpenApiAdapter.kt
@@ -3,6 +3,8 @@ package com.fx.user.adapter.`in`.web
 import com.fx.global.annotation.hexagonal.WebInputAdapter
 import com.fx.global.api.Api
 import com.fx.user.adapter.`in`.web.dto.user.EmailRequest
+import com.fx.user.adapter.`in`.web.dto.user.EmailVerifyRequest
+import com.fx.user.adapter.`in`.web.dto.user.EmailVerifyResponse
 import com.fx.user.application.port.`in`.EmailVerificationUseCase
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
@@ -17,13 +19,21 @@ class EmailVerificationOpenApiAdapter(
     private val emailVerificationUseCase: EmailVerificationUseCase
 ) {
 
+    @Operation(summary = "이메일 인증코드 발송", description = "회원가입 전 이메일 인증을 진행합니다.<br> 입력한 이메일로 5자리 인증코드가 발송됩니다.")
     @PostMapping
-    @Operation(summary = "이메일 인증", description = "회원가입 전 이메일 인증을 진행합니다.")
     fun sendVerificationCode(
         @RequestBody @Valid emailRequest: EmailRequest
     ): ResponseEntity<Api<Boolean>> =
         Api.OK(emailVerificationUseCase.sendVerificationCode(emailRequest.email), "인증코드가 발송되었습니다.")
 
-
+    @Operation(summary = "이메일 인증 확인", description = "사용자가 입력한 인증 코드를 확인합니다. <br> 인증이 완료되면 임시토큰을 발급하며, 이 토큰은 회원가입 시 사용됩니다.")
+    @PostMapping("/verify")
+    fun verifyCode(
+        @RequestBody @Valid emailVerifyRequest: EmailVerifyRequest
+    ): ResponseEntity<Api<EmailVerifyResponse>> =
+        Api.OK(
+            EmailVerifyResponse(
+                emailVerificationUseCase.verifyCodeAndIssueTempToken(emailVerifyRequest.toCommand())
+            ), "검증이 완료되었습니다.")
 
 }

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/UserOpenApiAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/UserOpenApiAdapter.kt
@@ -22,7 +22,7 @@ class UserOpenApiAdapter(
     private val userCommandUseCase: UserCommandUseCase
 ) {
 
-    @Operation(summary = "회원가입")
+    @Operation(summary = "회원가입", description = "회원가입 API 를 사용하기 전 `POST /open-api/v1/email`, `POST /open-api/v1/email/verify` API 를 통해 TempToken 을 발급받아야 합니다.")
     @PostMapping("/signup")
     fun signUp(
         @RequestBody @Valid signUpRequest: UserSignUpRequest

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailRequest.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailRequest.kt
@@ -1,0 +1,14 @@
+package com.fx.user.adapter.`in`.web.dto.user
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class EmailRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message ="이메일 형식이 올바르지 않습니다.")
+    @field:Size(max = 200, message = "이메일은 200자 이내여야 합니다.")
+    val email: String,
+
+)

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailVerifyRequest.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailVerifyRequest.kt
@@ -1,0 +1,28 @@
+package com.fx.user.adapter.`in`.web.dto.user
+
+import com.fx.user.application.port.`in`.dto.EmailVerifyCommand
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class EmailVerifyRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message ="이메일 형식이 올바르지 않습니다.")
+    @field:Size(max = 200, message = "이메일은 200자 이내여야 합니다.")
+    val email: String,
+
+    @field:Size(min = 5, max = 5, message = "인증코드는 5자리 숫자여야 합니다.")
+    @field:Pattern(regexp = "^[0-9]+$", message = "인증코드는 숫자만 입력 가능합니다.")
+    val verificationCode: String
+
+) {
+
+    fun toCommand(): EmailVerifyCommand =
+        EmailVerifyCommand(
+            email = this.email,
+            verificationCode = this.verificationCode
+        )
+
+}

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailVerifyResponse.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/EmailVerifyResponse.kt
@@ -1,0 +1,7 @@
+package com.fx.user.adapter.`in`.web.dto.user
+
+data class EmailVerifyResponse(
+
+    val tempToken: String
+
+)

--- a/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/UserSignUpRequest.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/in/web/dto/user/UserSignUpRequest.kt
@@ -8,6 +8,9 @@ import jakarta.validation.constraints.Size
 
 data class UserSignUpRequest(
 
+    @field:NotBlank(message = "이메일 인증 후 임시토큰을 입력해야 합니다.")
+    val tempToken: String,
+
     @field:NotBlank(message = "이메일은 필수입니다.")
     @field:Email(message ="이메일 형식이 올바르지 않습니다.")
     @field:Size(max = 200, message = "이메일은 200자 이내여야 합니다.")
@@ -32,6 +35,7 @@ data class UserSignUpRequest(
 ) {
     fun toCommand(): UserSignUpCommand {
         return UserSignUpCommand(
+            tempToken = this.tempToken,
             email = this.email,
             password = this.password,
             phone = this.phone,

--- a/user/src/main/kotlin/com/fx/user/adapter/out/message/KafkaMessageProducerAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/message/KafkaMessageProducerAdapter.kt
@@ -2,13 +2,13 @@ package com.fx.user.adapter.out.message
 
 import com.fx.global.annotation.hexagonal.MessageOutputAdapter
 import com.fx.global.dto.MediaMappingEventDto
-import com.fx.user.application.port.out.message.MessageProducerUseCase
+import com.fx.user.application.port.out.message.MessageProducerPort
 import org.springframework.kafka.core.KafkaTemplate
 
 @MessageOutputAdapter
 class KafkaMessageProducerAdapter(
     private val kafkaTemplate: KafkaTemplate<String, MediaMappingEventDto>,
-) : MessageProducerUseCase {
+) : MessageProducerPort {
 
     override fun sendMapping(mediaMappingEventDto: MediaMappingEventDto) {
         kafkaTemplate.send("media-mapping", mediaMappingEventDto)

--- a/user/src/main/kotlin/com/fx/user/adapter/out/message/SmtpMailAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/message/SmtpMailAdapter.kt
@@ -1,0 +1,48 @@
+package com.fx.user.adapter.out.message
+
+import com.fx.global.annotation.hexagonal.MessageOutputAdapter
+import com.fx.user.application.port.out.message.MailSenderPort
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeMessage
+import org.springframework.mail.javamail.JavaMailSender
+
+@MessageOutputAdapter
+class SmtpMailAdapter(
+    private val javaMailSender: JavaMailSender // `Could not autowire` IntelliJ 문제이므로 무시
+) : MailSenderPort {
+
+    override fun sendVerificationCode(email: String, code: String) {
+        try {
+            val message: MimeMessage = javaMailSender.createMimeMessage()
+            message.setRecipients(MimeMessage.RecipientType.TO, InternetAddress.parse(email))
+            message.subject = "[Parrot] 이메일 인증 코드 발송"
+            message.setContent(buildEmailBody(code), "text/html; charset=utf-8")
+
+            javaMailSender.send(message)
+        } catch (e: Exception) {
+            throw RuntimeException("메일 전송 실패", e) // TODO Exception 처리
+        }
+    }
+
+    private fun buildEmailBody(code: String): String {
+        return """
+        <html>
+        <body style="background-color:#ffffff; max-width:600px; margin:0 auto; padding:40px; font-family:sans-serif;">
+            <h1 style="color:#4D6EF4;">Parrot 이메일 인증</h1>
+            <p style="font-size:16px; line-height:1.6;">
+                안녕하세요, Parrot입니다.<br/>
+                서비스 이용을 위해 이메일 주소 확인이 필요합니다.<br/>
+                아래 인증 코드를 입력해주세요.
+            </p>
+            <div style="margin:30px auto; font-size:30px; text-align:center; padding:20px; background:#f4f4f4; border-radius:8px; color:#000000; font-weight:bold; letter-spacing:5px;">
+                $code
+            </div>
+            <p style="font-size:12px; color:#888888; text-align:center; margin-top:40px;">
+                ※ 본 메일은 발신 전용입니다. 궁금한 점은 Parrot 고객센터로 문의해주세요.
+            </p>
+        </body>
+        </html>
+    """.trimIndent()
+    }
+
+}

--- a/user/src/main/kotlin/com/fx/user/adapter/out/persistence/SignUpVerificationAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/persistence/SignUpVerificationAdapter.kt
@@ -3,7 +3,6 @@ package com.fx.user.adapter.out.persistence
 import com.fx.global.annotation.hexagonal.CacheAdapter
 import com.fx.user.application.port.out.persistence.SignUpVerificationPort
 import org.springframework.data.redis.core.StringRedisTemplate
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 @CacheAdapter
@@ -23,19 +22,17 @@ class SignUpVerificationAdapter(
         redisTemplate.delete("verification:$email")
     }
 
-
-    override fun saveTempEmail(email: String, code: String): String {
-        val token = UUID.randomUUID().toString()
-        redisTemplate.opsForValue().set("tempEmail:$token", email, 10, TimeUnit.MINUTES)
+    override fun saveTempToken(email: String, token: String): String {
+        redisTemplate.opsForValue().set("tempToken:$token", email, 10, TimeUnit.MINUTES)
         return token
     }
 
     override fun getEmailByToken(token: String): String? {
-        return redisTemplate.opsForValue().get("tempEmail:$token")
+        return redisTemplate.opsForValue().get("tempToken:$token")
     }
 
-    override fun deleteTempEmail(token: String) {
-        redisTemplate.delete("tempEmail:$token")
+    override fun deleteTempToken(token: String) {
+        redisTemplate.delete("tempToken:$token")
     }
 
 }

--- a/user/src/main/kotlin/com/fx/user/adapter/out/persistence/SignUpVerificationAdapter.kt
+++ b/user/src/main/kotlin/com/fx/user/adapter/out/persistence/SignUpVerificationAdapter.kt
@@ -1,0 +1,41 @@
+package com.fx.user.adapter.out.persistence
+
+import com.fx.global.annotation.hexagonal.CacheAdapter
+import com.fx.user.application.port.out.persistence.SignUpVerificationPort
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@CacheAdapter
+class SignUpVerificationAdapter(
+    private val redisTemplate: StringRedisTemplate
+) : SignUpVerificationPort {
+
+    override fun saveVerificationCode(email: String, code: String, minutes: Long) {
+        redisTemplate.opsForValue().set("verification:$email", code, minutes, TimeUnit.MINUTES)
+    }
+
+    override fun getVerificationCode(email: String): String? {
+        return redisTemplate.opsForValue().get("verification:$email")
+    }
+
+    override fun deleteVerificationCode(email: String) {
+        redisTemplate.delete("verification:$email")
+    }
+
+
+    override fun saveTempEmail(email: String, code: String): String {
+        val token = UUID.randomUUID().toString()
+        redisTemplate.opsForValue().set("tempEmail:$token", email, 10, TimeUnit.MINUTES)
+        return token
+    }
+
+    override fun getEmailByToken(token: String): String? {
+        return redisTemplate.opsForValue().get("tempEmail:$token")
+    }
+
+    override fun deleteTempEmail(token: String) {
+        redisTemplate.delete("tempEmail:$token")
+    }
+
+}

--- a/user/src/main/kotlin/com/fx/user/application/port/in/EmailVerificationUseCase.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/in/EmailVerificationUseCase.kt
@@ -1,5 +1,11 @@
 package com.fx.user.application.port.`in`
 
+import com.fx.user.application.port.`in`.dto.EmailVerifyCommand
+
 interface EmailVerificationUseCase {
+
     fun sendVerificationCode(email: String): Boolean
+
+    fun verifyCodeAndIssueTempToken(emailVerifyCommand: EmailVerifyCommand): String
+
 }

--- a/user/src/main/kotlin/com/fx/user/application/port/in/EmailVerificationUseCase.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/in/EmailVerificationUseCase.kt
@@ -1,0 +1,5 @@
+package com.fx.user.application.port.`in`
+
+interface EmailVerificationUseCase {
+    fun sendVerificationCode(email: String): Boolean
+}

--- a/user/src/main/kotlin/com/fx/user/application/port/in/dto/EmailVerifyCommand.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/in/dto/EmailVerifyCommand.kt
@@ -1,0 +1,9 @@
+package com.fx.user.application.port.`in`.dto
+
+data class EmailVerifyCommand(
+
+    val email: String,
+
+    val verificationCode: String
+
+)

--- a/user/src/main/kotlin/com/fx/user/application/port/in/dto/UserSignUpCommand.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/in/dto/UserSignUpCommand.kt
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.Size
 
 data class UserSignUpCommand(
 
+    @field:NotBlank(message = "이메일 인증 후 임시토큰을 입력해야 합니다.")
+    val tempToken: String,
+
     @field:NotBlank(message = "이메일은 필수입니다.")
     @field:Email(message ="이메일 형식이 올바르지 않습니다.")
     @field:Size(max = 200, message = "이메일은 200자 이내여야 합니다.")

--- a/user/src/main/kotlin/com/fx/user/application/port/out/message/MailSenderPort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/out/message/MailSenderPort.kt
@@ -1,0 +1,7 @@
+package com.fx.user.application.port.out.message
+
+interface MailSenderPort {
+
+    fun sendVerificationCode(email: String, code: String)
+
+}

--- a/user/src/main/kotlin/com/fx/user/application/port/out/message/MessageProducerPort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/out/message/MessageProducerPort.kt
@@ -2,7 +2,7 @@ package com.fx.user.application.port.out.message
 
 import com.fx.global.dto.MediaMappingEventDto
 
-interface MessageProducerUseCase {
+interface MessageProducerPort {
 
     fun sendMapping(mediaMappingEventDto: MediaMappingEventDto)
 

--- a/user/src/main/kotlin/com/fx/user/application/port/out/persistence/SignUpVerificationPort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/out/persistence/SignUpVerificationPort.kt
@@ -1,7 +1,5 @@
 package com.fx.user.application.port.out.persistence
 
-import kotlin.time.Duration
-
 interface SignUpVerificationPort {
 
     /**
@@ -30,7 +28,7 @@ interface SignUpVerificationPort {
      * @param code 인증 코드
      * @return 회원가입 완료용 토큰
      */
-    fun saveTempEmail(email: String, code: String): String
+    fun saveTempToken(email: String, token: String): String
 
     /**
      * 토큰으로 이메일 조회
@@ -38,8 +36,8 @@ interface SignUpVerificationPort {
     fun getEmailByToken(token: String): String?
 
     /**
-     * 임시 유저 삭제
+     * 임시 이메일 삭제
      */
-    fun deleteTempEmail(token: String)
+    fun deleteTempToken(token: String)
 
 }

--- a/user/src/main/kotlin/com/fx/user/application/port/out/persistence/SignUpVerificationPort.kt
+++ b/user/src/main/kotlin/com/fx/user/application/port/out/persistence/SignUpVerificationPort.kt
@@ -1,0 +1,45 @@
+package com.fx.user.application.port.out.persistence
+
+import kotlin.time.Duration
+
+interface SignUpVerificationPort {
+
+    /**
+     * 이메일 인증 코드 저장
+     * @param email 인증할 이메일
+     * @param code 생성된 인증 코드
+     * @param minutes 인증 코드 만료 시간
+     */
+    fun saveVerificationCode(email: String, code: String, minutes: Long)
+
+    /**
+     * 이메일 인증 코드 조회
+     * @param email 조회할 이메일
+     * @return 인증 코드 또는 null
+     */
+    fun getVerificationCode(email: String): String?
+
+    /**
+     * 이메일 인증 코드 삭제
+     */
+    fun deleteVerificationCode(email: String)
+
+    /**
+     * 임시 이메일 저장
+     * @param email 이메일
+     * @param code 인증 코드
+     * @return 회원가입 완료용 토큰
+     */
+    fun saveTempEmail(email: String, code: String): String
+
+    /**
+     * 토큰으로 이메일 조회
+     */
+    fun getEmailByToken(token: String): String?
+
+    /**
+     * 임시 유저 삭제
+     */
+    fun deleteTempEmail(token: String)
+
+}

--- a/user/src/main/kotlin/com/fx/user/application/service/EmailVerificationService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/EmailVerificationService.kt
@@ -1,12 +1,17 @@
 package com.fx.user.application.service
 
 import com.fx.user.application.port.`in`.EmailVerificationUseCase
+import com.fx.user.application.port.`in`.dto.EmailVerifyCommand
 import com.fx.user.application.port.out.message.MailSenderPort
 import com.fx.user.application.port.out.persistence.SignUpVerificationPort
+import com.fx.user.exception.EmailVerificationException
+import com.fx.user.exception.errorcode.EmailVerificationErrorCode
+import jakarta.transaction.Transactional
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.springframework.stereotype.Service
+import java.util.UUID
 import kotlin.random.Random
 
 @Service
@@ -30,4 +35,22 @@ class EmailVerificationService(
 
         return true
     }
+
+
+    @Transactional
+    override fun verifyCodeAndIssueTempToken(emailVerifyCommand: EmailVerifyCommand): String {
+        val savedVerificationCode = signUpVerificationPort.getVerificationCode(emailVerifyCommand.email)
+            ?: throw EmailVerificationException(EmailVerificationErrorCode.CODE_NOT_FOUND)
+
+        if (savedVerificationCode != emailVerifyCommand.verificationCode)
+            throw EmailVerificationException(EmailVerificationErrorCode.CODE_MISMATCH)
+
+        // 인증 성공 → 임시 토큰 발급
+        val tempToken = UUID.randomUUID().toString()
+        signUpVerificationPort.saveTempToken(emailVerifyCommand.email, tempToken) // TTL 10분
+        signUpVerificationPort.deleteVerificationCode(emailVerifyCommand.email) // 인증 코드 삭제
+
+        return tempToken
+    }
+
 }

--- a/user/src/main/kotlin/com/fx/user/application/service/EmailVerificationService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/EmailVerificationService.kt
@@ -1,0 +1,33 @@
+package com.fx.user.application.service
+
+import com.fx.user.application.port.`in`.EmailVerificationUseCase
+import com.fx.user.application.port.out.message.MailSenderPort
+import com.fx.user.application.port.out.persistence.SignUpVerificationPort
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.springframework.stereotype.Service
+import kotlin.random.Random
+
+@Service
+class EmailVerificationService(
+    private val signUpVerificationPort: SignUpVerificationPort,
+    private val mailSenderPort: MailSenderPort
+) : EmailVerificationUseCase {
+
+    private val backgroundScope = CoroutineScope(Dispatchers.IO)
+
+    override fun sendVerificationCode(email: String): Boolean {
+        // 인증코드 5자리 생성
+        val verificationCode = Random.nextInt(0, 100000).toString().padStart(5, '0')
+
+        // TTL 5분
+        signUpVerificationPort.saveVerificationCode(email, verificationCode, 5L);
+
+        backgroundScope.launch {
+            mailSenderPort.sendVerificationCode(email, verificationCode)
+        }
+
+        return true
+    }
+}

--- a/user/src/main/kotlin/com/fx/user/application/service/ProfileCommandService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/ProfileCommandService.kt
@@ -4,7 +4,7 @@ import com.fx.global.dto.Context
 import com.fx.global.dto.MediaMappingEventDto
 import com.fx.user.application.port.`in`.ProfileCommandUseCase
 import com.fx.user.application.port.`in`.dto.ProfileUpdateCommand
-import com.fx.user.application.port.out.message.MessageProducerUseCase
+import com.fx.user.application.port.out.message.MessageProducerPort
 import com.fx.user.application.port.out.persistence.ProfilePersistencePort
 import com.fx.user.exception.ProfileException
 import com.fx.user.exception.errorcode.ProfileErrorCode
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
 @Service
 class ProfileCommandService(
     private val profilePersistencePort: ProfilePersistencePort,
-    private val messageProducerUseCase: MessageProducerUseCase
+    private val messageProducerPort: MessageProducerPort
 ): ProfileCommandUseCase {
 
     @Transactional
@@ -32,7 +32,7 @@ class ProfileCommandService(
 
         val mediaIds = updateCommand.mediaId?.let { listOf(it) } ?: emptyList()
 
-        messageProducerUseCase.sendMapping(
+        messageProducerPort.sendMapping(
             MediaMappingEventDto(context = Context.PROFILE, referenceId = updatedProfile.id, userId = updatedProfile.userId, mediaIds = mediaIds)
         )
 

--- a/user/src/main/kotlin/com/fx/user/application/service/UserCommandService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/UserCommandService.kt
@@ -8,14 +8,17 @@ import com.fx.user.application.port.`in`.dto.UserOAuthCommand
 import com.fx.user.application.port.`in`.dto.UserSignUpCommand
 import com.fx.user.application.port.out.message.MessageProducerPort
 import com.fx.user.application.port.out.persistence.ProfilePersistencePort
+import com.fx.user.application.port.out.persistence.SignUpVerificationPort
 import com.fx.user.application.port.out.persistence.UserPersistencePort
 import com.fx.user.application.port.out.security.JwtProviderPort
 import com.fx.user.application.port.out.security.PasswordEncoderPort
 import com.fx.user.domain.Profile
 import com.fx.user.domain.TokenInfo
 import com.fx.user.domain.User
+import com.fx.user.exception.EmailVerificationException
 import com.fx.user.exception.ProfileException
 import com.fx.user.exception.UserException
+import com.fx.user.exception.errorcode.EmailVerificationErrorCode
 import com.fx.user.exception.errorcode.ProfileErrorCode
 import com.fx.user.exception.errorcode.UserErrorCode
 import org.springframework.stereotype.Service
@@ -27,11 +30,19 @@ class UserCommandService(
     private val profilePersistencePort: ProfilePersistencePort,
     private val jwtProviderPort: JwtProviderPort,
     private val passwordEncoderPort: PasswordEncoderPort,
-    private val messageProducerPort: MessageProducerPort
+    private val messageProducerPort: MessageProducerPort,
+    private val signUpVerificationPort: SignUpVerificationPort
 ) : UserCommandUseCase {
 
     @Transactional
     override fun signUp(signUpCommand: UserSignUpCommand): User {
+
+        // 이메일 인증 후 발급받은 토큰 조회
+        val savedEmail = signUpVerificationPort.getEmailByToken(signUpCommand.tempToken)
+            ?: throw EmailVerificationException(EmailVerificationErrorCode.TOKEN_NOT_FOUND)
+
+        if (savedEmail != signUpCommand.email)
+            throw EmailVerificationException(EmailVerificationErrorCode.UNAUTHORIZED_VERIFICATION_ACCESS)
 
         // email, nickname 존재시 예외
         if (userPersistencePort.existsByEmail(signUpCommand.email)) {
@@ -53,11 +64,14 @@ class UserCommandService(
             val savedProfile = profilePersistencePort.save(
                 Profile.createProfile(userId, signUpCommand.nickname)
             )
-            messageProducerPort.sendMapping(
-                MediaMappingEventDto(context = Context.PROFILE, referenceId = savedProfile.id, userId = userId, mediaIds = mediaIds)
-            )
+            if (mediaIds.isNotEmpty()) {
+                messageProducerPort.sendMapping(MediaMappingEventDto(context = Context.PROFILE, referenceId = savedProfile.id, userId = userId, mediaIds = mediaIds)
+                )
+            }
         } ?: throw UserException(UserErrorCode.USER_ID_NULL)
 
+        // 토큰 삭제
+        signUpVerificationPort.deleteTempToken(signUpCommand.tempToken)
         return savedUser
     }
 

--- a/user/src/main/kotlin/com/fx/user/application/service/UserCommandService.kt
+++ b/user/src/main/kotlin/com/fx/user/application/service/UserCommandService.kt
@@ -6,7 +6,7 @@ import com.fx.user.application.port.`in`.UserCommandUseCase
 import com.fx.user.application.port.`in`.dto.UserLoginCommand
 import com.fx.user.application.port.`in`.dto.UserOAuthCommand
 import com.fx.user.application.port.`in`.dto.UserSignUpCommand
-import com.fx.user.application.port.out.message.MessageProducerUseCase
+import com.fx.user.application.port.out.message.MessageProducerPort
 import com.fx.user.application.port.out.persistence.ProfilePersistencePort
 import com.fx.user.application.port.out.persistence.UserPersistencePort
 import com.fx.user.application.port.out.security.JwtProviderPort
@@ -27,7 +27,7 @@ class UserCommandService(
     private val profilePersistencePort: ProfilePersistencePort,
     private val jwtProviderPort: JwtProviderPort,
     private val passwordEncoderPort: PasswordEncoderPort,
-    private val messageProducerUseCase: MessageProducerUseCase
+    private val messageProducerPort: MessageProducerPort
 ) : UserCommandUseCase {
 
     @Transactional
@@ -53,7 +53,7 @@ class UserCommandService(
             val savedProfile = profilePersistencePort.save(
                 Profile.createProfile(userId, signUpCommand.nickname)
             )
-            messageProducerUseCase.sendMapping(
+            messageProducerPort.sendMapping(
                 MediaMappingEventDto(context = Context.PROFILE, referenceId = savedProfile.id, userId = userId, mediaIds = mediaIds)
             )
         } ?: throw UserException(UserErrorCode.USER_ID_NULL)

--- a/user/src/main/kotlin/com/fx/user/exception/EmailVerificationException.kt
+++ b/user/src/main/kotlin/com/fx/user/exception/EmailVerificationException.kt
@@ -1,0 +1,8 @@
+package com.fx.user.exception
+
+import com.fx.global.api.ErrorCodeIfs
+
+class EmailVerificationException(
+    val errorCodeIfs: ErrorCodeIfs,
+    cause: Throwable? = null
+) : RuntimeException(errorCodeIfs.message, cause)

--- a/user/src/main/kotlin/com/fx/user/exception/errorcode/EmailVerificationErrorCode.kt
+++ b/user/src/main/kotlin/com/fx/user/exception/errorcode/EmailVerificationErrorCode.kt
@@ -1,0 +1,16 @@
+package com.fx.user.exception.errorcode
+
+import com.fx.global.api.ErrorCodeIfs
+import org.springframework.http.HttpStatus
+
+enum class EmailVerificationErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCodeIfs {
+
+    CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
+    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 인증 토큰입니다."),
+    UNAUTHORIZED_VERIFICATION_ACCESS(HttpStatus.UNAUTHORIZED, "이메일 인증 권한이 없습니다.")
+
+}

--- a/user/src/main/kotlin/com/fx/user/exception/handler/EmailVerificationExceptionHandler.kt
+++ b/user/src/main/kotlin/com/fx/user/exception/handler/EmailVerificationExceptionHandler.kt
@@ -1,0 +1,22 @@
+package com.fx.user.exception.handler
+
+import com.fx.global.api.Api
+import com.fx.global.api.ErrorCodeIfs
+import com.fx.user.exception.EmailVerificationException
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class EmailVerificationExceptionHandler {
+
+    private val log = LoggerFactory.getLogger(EmailVerificationExceptionHandler::class.java)
+
+    @ExceptionHandler(EmailVerificationException::class)
+    fun handleUserException(e: EmailVerificationException): ResponseEntity<Api<ErrorCodeIfs>> {
+        log.error("", e)
+        return Api.ERROR(e.errorCodeIfs)
+    }
+
+}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -41,6 +41,21 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls: # 보안 연결
+            enable: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
 eureka:
   instance:
     prefer-ip-address: true


### PR DESCRIPTION
# feat: 회원가입 Email 인증 API 개발

## 회원가입 프로세스

1. `POST /open-api/v1/email` - 이메일로 인증 코드 발송
2. `POST /open-api/v1/email/verify` - 발송된 인증코드를 검증하며, 회원가입 시 입력해야 할 임시 토큰 반환
3. `POST /open-api/v1/users/signup` - 회원가입 시 임시 토큰을 포함해 회원가입을 진행